### PR TITLE
Limit backend calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 
 ext {
-    glowingBearVersion = '0.0.1-SNAPSHOT'
+    glowingBearVersion = '0.0.1-luke-acc-SNAPSHOT'
     nodeVersion = '7.10.1'
     gradleWrapperVersion = '4.0'
 }

--- a/src/app/config/env.json
+++ b/src/app/config/env.json
@@ -1,3 +1,3 @@
 {
-  "env": "prod"
+  "env": "dev"
 }

--- a/src/app/config/env.json
+++ b/src/app/config/env.json
@@ -1,3 +1,3 @@
 {
-  "env": "dev"
+  "env": "prod"
 }

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-export/gb-export.component.html
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-export/gb-export.component.html
@@ -5,7 +5,7 @@
     <h5>Create new export for the currently selected data</h5>
   </div>
 
-  <div *ngIf="exportFormats.length > 0" class="gb-export-format-container">
+  <div *ngIf="!isLoadingExportFormats && exportFormats.length > 0" class="gb-export-format-container">
 
     <!-- area to indicate which data formats to export -->
     <div class="gb-export-format-header">Select data types and formats to export:</div>

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-projection/gb-projection.component.html
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-projection/gb-projection.component.html
@@ -1,23 +1,35 @@
 <div>
-  <div class="container form-inline">
-    <button type="button" (click)="expandAll(true)"
-            class="btn btn-primary btn-sm gb-data-selection-control-btn">Expand All</button>
-    <span>&nbsp;</span>
-    <button type="button" (click)="expandAll(false)"
-            class="btn btn-primary btn-sm gb-data-selection-control-btn">Collapse All</button>
-    <span style="color: lightgray">&nbsp;&middot;&nbsp;</span>
-    <button type="button" (click)="checkAll(true)"
-            class="btn btn-primary btn-sm gb-data-selection-control-btn">Check All</button>
-    <span>&nbsp;</span>
-    <button type="button" (click)="checkAll(false)"
-            class="btn btn-primary btn-sm gb-data-selection-control-btn">Check None</button>
-  </div>
+  <div *ngIf="!isLoading() && hasSelectionCount">
 
-  <p-tree [value]="projectionTreeData"
+    <div class="row form-inline">
+          <div class="col-12">
+              <button type="button" (click)="expandAll(true)"
+                      class="btn btn-primary btn-sm gb-data-selection-control-btn">Expand All</button>
+              <span>&nbsp;</span>
+              <button type="button" (click)="expandAll(false)"
+                      class="btn btn-primary btn-sm gb-data-selection-control-btn">Collapse All</button>
+              <span style="color: lightgray">&nbsp;&middot;&nbsp;</span>
+              <button type="button" (click)="checkAll(true)"
+                      class="btn btn-primary btn-sm gb-data-selection-control-btn">Check All</button>
+              <span>&nbsp;</span>
+              <button type="button" (click)="checkAll(false)"
+                      class="btn btn-primary btn-sm gb-data-selection-control-btn">Check None</button>
+          </div>
+    </div>
+
+    <p-tree [value]="projectionTreeData"
           selectionMode="checkbox"
           (onNodeSelect)="updateCounts()"
           (onNodeUnselect)="updateCounts()"
           [(selection)]="selectedProjectionTreeData"
           styleClass="gb-projection-tree-container">
-  </p-tree>
+    </p-tree>
+
+  </div>
+  <!-- the spinning icon -->
+  <div *ngIf="isLoading() || !hasSelectionCount">
+    <i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i>
+    Loading tree for selected subject group ...
+  </div>
+
 </div>

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-projection/gb-projection.component.ts
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-projection/gb-projection.component.ts
@@ -32,13 +32,20 @@ export class GbProjectionComponent implements OnInit {
 
   updateCounts() {
     this.queryService.step = Step.II;
+    this.queryService.dirty_2 = true;
     if (this.queryService.instantCountUpdate_2) {
       this.queryService.updateCounts_2();
     }
+    this.treeNodeService.updateSelectionCount();
+  }
+
+  isLoading() {
+      return this.queryService.isLoadingTreeCounts_2;
   }
 
   checkAll(value: boolean) {
     if (value) {
+      this.selectedProjectionTreeData.length = 0;
       this.treeNodeService
         .checkProjectionTreeDataIterative(this.treeNodeService.projectionTreeData);
     } else {
@@ -52,4 +59,9 @@ export class GbProjectionComponent implements OnInit {
     this.treeNodeService
       .expandProjectionTreeDataIterative(this.treeNodeService.projectionTreeData, value);
   }
+
+  get hasSelectionCount(): boolean {
+    return this.treeNodeService.selectionCount !== undefined;
+  }
+
 }

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.css
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.css
@@ -11,12 +11,12 @@
   padding-bottom: 10px;
 }
 
-.patient-count-box {
+.subject-count-box {
   margin: 4px 4px 4px 4px;
   color: #373a3c;
 }
 
-.patient-count-box span {
+.subject-count-box span {
   border-radius: 4px;
   padding: 2px 8px 2px 4px;
 }

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.html
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.html
@@ -10,7 +10,7 @@
        class="criteria-box">
     <div class="subject-count-box">
       <i class="fa fa-spin fa-refresh fa-fw gb-spinner" [class.loading]="loadingStateInclusion == 'loading'"></i>
-      <span [@notifyState]="loadingStateInclusion">{{inclusionSubjectCount}} subjects included.</span>
+      <span [@notifyState]="loadingStateInclusion">{{formatNumber(inclusionSubjectCount)}} subjects included.</span>
     </div>
     <gb-constraint #rootInclusionConstraintComponent
                 [constraint]="rootInclusionConstraint"
@@ -22,7 +22,7 @@
        class="criteria-box">
     <div class="subject-count-box">
       <i class="fa fa-spin fa-refresh fa-fw gb-spinner" [class.loading]="loadingStateExclusion == 'loading'"></i>
-      <span [@notifyState]="loadingStateExclusion">{{exclusionSubjectCount}} subjects excluded.</span>
+      <span [@notifyState]="loadingStateExclusion">{{formatNumber(exclusionSubjectCount)}} subjects excluded.</span>
     </div>
     <gb-constraint #rootExclusionConstraintComponent
                 [constraint]="rootExclusionConstraint"
@@ -33,7 +33,7 @@
   <!-- Intersection calculation -->
   <div class="subject-count-box">
     <i class="fa fa-spin fa-refresh fa-fw gb-spinner" [class.loading]="loadingStateTotal == 'loading'"></i>
-    <span [@notifyState]="loadingStateTotal">{{subjectCount_1}} subjects match your selection.</span>
+    <span [@notifyState]="loadingStateTotal">{{formatNumber(subjectCount_1)}} subjects match your selection.</span>
   </div>
 
 </div>

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.html
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.html
@@ -10,7 +10,7 @@
        class="criteria-box">
     <div class="patient-count-box">
       <i class="fa fa-spin fa-refresh fa-fw gb-spinner" [class.loading]="loadingStateInclusion == 'loading'"></i>
-      <span [@notifyState]="loadingStateInclusion">{{inclusionPatientCount}} patients included.</span>
+      <span [@notifyState]="loadingStateInclusion">{{inclusionSubjectCount}} patients included.</span>
     </div>
     <gb-constraint #rootInclusionConstraintComponent
                 [constraint]="rootInclusionConstraint"
@@ -22,7 +22,7 @@
        class="criteria-box">
     <div class="patient-count-box">
       <i class="fa fa-spin fa-refresh fa-fw gb-spinner" [class.loading]="loadingStateExclusion == 'loading'"></i>
-      <span [@notifyState]="loadingStateExclusion">{{exclusionPatientCount}} patients excluded.</span>
+      <span [@notifyState]="loadingStateExclusion">{{exclusionSubjectCount}} patients excluded.</span>
     </div>
     <gb-constraint #rootExclusionConstraintComponent
                 [constraint]="rootExclusionConstraint"
@@ -33,7 +33,7 @@
   <!-- Intersection calculation -->
   <div class="patient-count-box">
     <i class="fa fa-spin fa-refresh fa-fw gb-spinner" [class.loading]="loadingStateTotal == 'loading'"></i>
-    <span [@notifyState]="loadingStateTotal">{{patientCount_1}} patients match your selection.</span>
+    <span [@notifyState]="loadingStateTotal">{{subjectCount_1}} patients match your selection.</span>
   </div>
 
 </div>

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.html
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.html
@@ -8,9 +8,9 @@
   <!-- Inclusion criteria -->
   <div #inclusionCriteriaBox
        class="criteria-box">
-    <div class="patient-count-box">
+    <div class="subject-count-box">
       <i class="fa fa-spin fa-refresh fa-fw gb-spinner" [class.loading]="loadingStateInclusion == 'loading'"></i>
-      <span [@notifyState]="loadingStateInclusion">{{inclusionSubjectCount}} patients included.</span>
+      <span [@notifyState]="loadingStateInclusion">{{inclusionSubjectCount}} subjects included.</span>
     </div>
     <gb-constraint #rootInclusionConstraintComponent
                 [constraint]="rootInclusionConstraint"
@@ -20,9 +20,9 @@
   <!-- Exclusion criteria -->
   <div #exclusionCriteriaBox
        class="criteria-box">
-    <div class="patient-count-box">
+    <div class="subject-count-box">
       <i class="fa fa-spin fa-refresh fa-fw gb-spinner" [class.loading]="loadingStateExclusion == 'loading'"></i>
-      <span [@notifyState]="loadingStateExclusion">{{exclusionSubjectCount}} patients excluded.</span>
+      <span [@notifyState]="loadingStateExclusion">{{exclusionSubjectCount}} subjects excluded.</span>
     </div>
     <gb-constraint #rootExclusionConstraintComponent
                 [constraint]="rootExclusionConstraint"
@@ -31,9 +31,9 @@
 
 
   <!-- Intersection calculation -->
-  <div class="patient-count-box">
+  <div class="subject-count-box">
     <i class="fa fa-spin fa-refresh fa-fw gb-spinner" [class.loading]="loadingStateTotal == 'loading'"></i>
-    <span [@notifyState]="loadingStateTotal">{{subjectCount_1}} patients match your selection.</span>
+    <span [@notifyState]="loadingStateTotal">{{subjectCount_1}} subjects match your selection.</span>
   </div>
 
 </div>

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
@@ -10,6 +10,7 @@ import {QueryService} from '../../../../services/query.service';
 import {ConstraintService} from '../../../../services/constraint.service';
 
 type LoadingState = 'loading' | 'complete';
+import { FormatHelper } from '../../../../util/format-helper';
 
 @Component({
   selector: 'gb-selection',
@@ -32,6 +33,8 @@ export class GbSelectionComponent implements OnInit {
 
   @ViewChild('rootInclusionConstraintComponent') rootInclusionConstraintComponent: GbConstraintComponent;
   @ViewChild('rootExclusionConstraintComponent') rootExclusionConstraintComponent: GbConstraintComponent;
+
+  get formatNumber() { return FormatHelper.formatNumber; }
 
   constructor(private constraintService: ConstraintService,
               private queryService: QueryService) {

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
@@ -38,7 +38,7 @@ export class GbSelectionComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.queryService.updateCounts_1(false, true);
+    this.queryService.updateCounts_1(true);
   }
 
   get subjectCount_1(): number {
@@ -63,7 +63,7 @@ export class GbSelectionComponent implements OnInit {
 
   clearCriteria() {
     this.constraintService.clearSelectionConstraint();
-    this.queryService.updateCounts_1(false, true);
+    this.queryService.updateCounts_1(true);
   }
 
   get loadingStateInclusion(): LoadingState {

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
@@ -6,10 +6,8 @@ import {
 } from '@angular/animations';
 import {GbConstraintComponent} from '../../constraint-components/gb-constraint/gb-constraint.component';
 import {CombinationConstraint} from '../../../../models/constraints/combination-constraint';
-import {QueryService} from '../../../../services/query.service';
+import { LoadingState, QueryService } from '../../../../services/query.service';
 import {ConstraintService} from '../../../../services/constraint.service';
-
-type LoadingState = 'loading' | 'complete';
 import { FormatHelper } from '../../../../util/format-helper';
 
 @Component({

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
@@ -8,6 +8,7 @@ import {GbConstraintComponent} from '../../constraint-components/gb-constraint/g
 import {CombinationConstraint} from '../../../../models/constraints/combination-constraint';
 import { LoadingState, QueryService } from '../../../../services/query.service';
 import {ConstraintService} from '../../../../services/constraint.service';
+import { TrueConstraint } from '../../../../models/constraints/true-constraint';
 import { FormatHelper } from '../../../../util/format-helper';
 
 @Component({
@@ -40,6 +41,7 @@ export class GbSelectionComponent implements OnInit {
 
   ngOnInit() {
     this.queryService.updateCounts_1(true);
+    this.queryService.updateStudyAndConceptCounts(new TrueConstraint());
   }
 
   get subjectCount_1(): number {
@@ -65,6 +67,7 @@ export class GbSelectionComponent implements OnInit {
   clearCriteria() {
     this.constraintService.clearSelectionConstraint();
     this.queryService.updateCounts_1(true);
+    this.queryService.updateStudyAndConceptCounts(new TrueConstraint());
   }
 
   get loadingStateInclusion(): LoadingState {

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-selection/gb-selection.component.ts
@@ -41,16 +41,16 @@ export class GbSelectionComponent implements OnInit {
     this.queryService.updateCounts_1(false, true);
   }
 
-  get patientCount_1(): number {
-    return this.queryService.patientCount_1;
+  get subjectCount_1(): number {
+    return this.queryService.subjectCount_1;
   }
 
-  get inclusionPatientCount(): number {
-    return this.queryService.inclusionPatientCount;
+  get inclusionSubjectCount(): number {
+    return this.queryService.inclusionSubjectCount;
   }
 
-  get exclusionPatientCount(): number {
-    return this.queryService.exclusionPatientCount;
+  get exclusionSubjectCount(): number {
+    return this.queryService.exclusionSubjectCount;
   }
 
   get rootInclusionConstraint(): CombinationConstraint {

--- a/src/app/modules/gb-data-selection-module/constraint-components/gb-constraint/gb-constraint.component.ts
+++ b/src/app/modules/gb-data-selection-module/constraint-components/gb-constraint/gb-constraint.component.ts
@@ -96,10 +96,15 @@ export class GbConstraintComponent implements OnInit {
   }
 
   protected updateCounts() {
-    this.queryService.step = Step.I;
-    if (this.queryService.instantCountUpdate_1) {
-      this.queryService.updateCounts_1();
-    }
+      this.queryService.step = Step.I;
+      if (this.queryService.instantCountUpdate_1) {
+          this.queryService.updateCounts_1();
+      } else {
+          this.queryService.dirty_1 = true;
+      }
+      if (this.treeNodeService.selectedProjectionTreeData.length > 0) {
+        this.queryService.dirty_2 = true;
+      }
   }
 
   get containerClass(): string {

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.css
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.css
@@ -20,6 +20,7 @@
 }
 
 .gb-data-selection-accordion-sub-header-2 {
+  background-color: rgba(51, 156, 144, 0.1);
   border-left: 1px solid lightgray;
   border-right: 1px solid lightgray;
   border-radius: 6px;

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.css
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.css
@@ -7,14 +7,35 @@
 }
 
 .gb-data-selection-container {
-  margin-top: 150px;
+  margin-top: 100px;
 }
 
 .gb-data-selection-accordion-header {
-  font-size: large;
-  opacity: .7;
 }
 
-.gb-data-selection-accordion-sub-header {
-  color: darkgray;
+.gb-data-selection-accordion-sub-header-1 {
+  font-size: large;
+  color: gray;
+  margin: 0em;
+}
+
+.gb-data-selection-accordion-sub-header-2 {
+  border-left: 1px solid lightgray;
+  border-right: 1px solid lightgray;
+  border-radius: 6px;
+  padding-left: 2em;
+}
+
+.gb-data-selection-accordion-sub-header-3 {
+  color: GrayText;
+  margin: 0em;
+}
+
+.gb-data-selection-emphasis-text {
+  color: #595959;
+  font-weight: bold;
+}
+
+.gb-data-selection-update-btn {
+  margin-left: 1em;
 }

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.css
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.css
@@ -25,6 +25,7 @@
   border-right: 1px solid lightgray;
   border-radius: 6px;
   padding-left: 2em;
+  overflow: hidden;
 }
 
 .gb-data-selection-accordion-sub-header-3 {
@@ -40,4 +41,14 @@
 .gb-data-selection-update-btn {
   margin-left: 1em;
   margin-right: 1em;
+}
+
+.gb-data-selection-dirty {
+  color: #1d5952;
+  background-color: rgba(255, 255, 121, 0.4);
+  border-color: rgba(140, 140, 0, 0.6);
+}
+.gb-data-selection-dirty:hover, .gb-data-selection-dirty:active {
+  background-color: rgba(255, 255, 0, 0.43);
+  border-color: #e2e200;
 }

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.css
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.css
@@ -39,4 +39,5 @@
 
 .gb-data-selection-update-btn {
   margin-left: 1em;
+  margin-right: 1em;
 }

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
@@ -11,16 +11,25 @@
             Step 1: Define the group of subjects for which you want to select data
           </div>
           <div class="gb-data-selection-accordion-sub-header-2">
-            <span class="gb-data-selection-accordion-sub-header-3">
-              <span class="gb-data-selection-emphasis-text">{{subjectCount_1}}</span> / {{subjectCount_0}}
-              <span class="gb-data-selection-emphasis-text">subjects</span> {{subjectCountPercentage_1}},
-              <span class="gb-data-selection-emphasis-text">{{observationCount_1}}</span> / {{observationCount_0}}
+            <span class="gb-data-selection-accordion-sub-header-3 float-left">
+              <span *ngIf="counting_1"><i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i></span>
+              <span *ngIf="!counting_1" class="gb-data-selection-emphasis-text">{{subjectCount_1}}</span>
+              / {{subjectCount_0}}
+              <span class="gb-data-selection-emphasis-text">subjects</span> {{subjectCountPercentage_1}}
+              &nbsp;&nbsp;
+              <span *ngIf="counting_1"><i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i></span>
+              <span *ngIf="!counting_1" class="gb-data-selection-emphasis-text">{{observationCount_1}}</span>
+              / {{observationCount_0}}
               <span class="gb-data-selection-emphasis-text">observations</span> {{observationCountPercentage_1}}
             </span>
             <span class="float-right">
               <button type="button"
+                      [disabled]="counting_1"
                       (click)="updateCounts_1($event)"
-                      class="btn btn-outline-primary btn-sm gb-data-selection-update-btn">Update counts</button>
+                      class="btn btn-outline-primary btn-sm gb-data-selection-update-btn
+                       {{dirty_1 ? 'gb-data-selection-dirty': ''}}">
+                {{counting_1 ? 'Updating counts ...' : 'Update counts'}}
+              </button>
             </span>
           </div>
         </div>
@@ -37,16 +46,30 @@
             subjects
           </div>
           <div class="gb-data-selection-accordion-sub-header-2">
-            <span class="gb-data-selection-accordion-sub-header-3">
-              <span class="gb-data-selection-emphasis-text">{{subjectCount_2}}</span> / {{subjectCount_1}}
-              <span class="gb-data-selection-emphasis-text">subjects</span> {{subjectCountPercentage_2}},
-              <span class="gb-data-selection-emphasis-text">{{observationCount_2}}</span> / {{observationCount_1}}
+            <span class="gb-data-selection-accordion-sub-header-3 float-left">
+              <span *ngIf="counting_2"><i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i></span>
+              <span *ngIf="!counting_2" class="gb-data-selection-emphasis-text">{{subjectCount_2}}</span>
+              / {{subjectCount_1}}
+              <span class="gb-data-selection-emphasis-text">subjects</span> {{subjectCountPercentage_2}}
+              &nbsp;&nbsp;
+              <span *ngIf="counting_2"><i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i></span>
+              <span *ngIf="!counting_2" class="gb-data-selection-emphasis-text">{{observationCount_2}}</span> / {{observationCount_1}}
               <span class="gb-data-selection-emphasis-text">observations</span> {{observationCountPercentage_2}}
+              &nbsp;&nbsp;
+              <span class="gb-data-selection-emphasis-text">{{selectedConceptCount}}</span> / {{conceptCount_2}}
+              <span class="gb-data-selection-emphasis-text">concepts</span> {{selectedConceptCountPercentage}}
+              &nbsp;&nbsp;
+              <span class="gb-data-selection-emphasis-text">{{selectedStudyCount}}</span> / {{studyCount_2}}
+              <span class="gb-data-selection-emphasis-text">concepts</span> {{selectedStudyCountPercentage}}
             </span>
             <span class="float-right">
               <button type="button"
+                      [disabled]="counting_2"
                       (click)="updateCounts_2($event)"
-                      class="btn btn-outline-primary btn-sm gb-data-selection-update-btn">Update counts</button>
+                      class="btn btn-outline-primary btn-sm gb-data-selection-update-btn
+                        {{dirty_2 ? 'gb-data-selection-dirty': ''}}">
+                {{counting_2 ? 'Updating counts ...' : 'Update counts'}}
+              </button>
             </span>
           </div>
         </div>
@@ -69,7 +92,8 @@
           </div>
           <div class="form-inline gb-data-selection-accordion-sub-header-2">
             <div class="gb-data-selection-accordion-sub-header-3">
-              <span class="gb-data-selection-emphasis-text">{{subjectCount_2}} subjects</span>,
+              <span class="gb-data-selection-emphasis-text">{{subjectCount_2}} subjects</span>
+              &nbsp;&nbsp;
               <span class="gb-data-selection-emphasis-text">{{observationCount_2}} observations</span>
             </div>
           </div>

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
@@ -10,18 +10,18 @@
           <div class="gb-data-selection-accordion-sub-header-1">
             Step 1: Define the group of subjects for which you want to select data
           </div>
-          <div class="form-inline gb-data-selection-accordion-sub-header-2">
-            <div class="gb-data-selection-accordion-sub-header-3">
+          <div class="gb-data-selection-accordion-sub-header-2">
+            <span class="gb-data-selection-accordion-sub-header-3">
               <span class="gb-data-selection-emphasis-text">{{subjectCount_1}}</span> / {{subjectCount_0}}
               <span class="gb-data-selection-emphasis-text">subjects</span> {{subjectCountPercentage_1}},
               <span class="gb-data-selection-emphasis-text">{{observationCount_1}}</span> / {{observationCount_0}}
               <span class="gb-data-selection-emphasis-text">observations</span> {{observationCountPercentage_1}}
-            </div>
-            <div class="float-right">
+            </span>
+            <span class="float-right">
               <button type="button"
                       (click)="updateCounts_1($event)"
                       class="btn btn-outline-primary btn-sm gb-data-selection-update-btn">Update counts</button>
-            </div>
+            </span>
           </div>
         </div>
       </md2-accordion-header>
@@ -36,18 +36,18 @@
             Step 2: Select the relevant data of your group of
             subjects
           </div>
-          <div class="form-inline gb-data-selection-accordion-sub-header-2">
-            <div class="gb-data-selection-accordion-sub-header-3">
+          <div class="gb-data-selection-accordion-sub-header-2">
+            <span class="gb-data-selection-accordion-sub-header-3">
               <span class="gb-data-selection-emphasis-text">{{subjectCount_2}}</span> / {{subjectCount_1}}
               <span class="gb-data-selection-emphasis-text">subjects</span> {{subjectCountPercentage_2}},
               <span class="gb-data-selection-emphasis-text">{{observationCount_2}}</span> / {{observationCount_1}}
               <span class="gb-data-selection-emphasis-text">observations</span> {{observationCountPercentage_2}}
-            </div>
-            <div class="float-right">
+            </span>
+            <span class="float-right">
               <button type="button"
                       (click)="updateCounts_2($event)"
                       class="btn btn-outline-primary btn-sm gb-data-selection-update-btn">Update counts</button>
-            </div>
+            </span>
           </div>
         </div>
       </md2-accordion-header>

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
@@ -6,14 +6,24 @@
     <!-- The 1st step -->
     <md2-accordion-tab [active]="true">
       <md2-accordion-header>
-        <span class="gb-data-selection-accordion-header">Step 1: Define the group of subjects for which you
-          want to select data</span>
-        <!--<span class="gb-data-selection-accordion-sub-header">-->
-          <!--({{patientCount_1}} {{singularOrPlural('patient', patientCount_1)}},-->
-          <!--with {{observationCount_1}} {{singularOrPlural('observation', observationCount_1)}},-->
-          <!--in {{conceptCount_1}} {{singularOrPlural('concept', conceptCount_1)}} and-->
-          <!--{{studyCount_1}} {{singularOrPlural('study', studyCount_1)}})-->
-        <!--</span>-->
+        <div class="gb-data-selection-accordion-header">
+          <div class="gb-data-selection-accordion-sub-header-1">
+            Step 1: Define the group of subjects for which you want to select data
+          </div>
+          <div class="form-inline gb-data-selection-accordion-sub-header-2">
+            <div class="gb-data-selection-accordion-sub-header-3">
+              <span class="gb-data-selection-emphasis-text">{{subjectCount_1}}</span> / {{subjectCount_0}}
+              <span class="gb-data-selection-emphasis-text">subjects</span> {{subjectCountPercentage_1}},
+              <span class="gb-data-selection-emphasis-text">{{observationCount_1}}</span> / {{observationCount_0}}
+              <span class="gb-data-selection-emphasis-text">observations</span> {{observationCountPercentage_1}}
+            </div>
+            <div class="float-right">
+              <button type="button"
+                      (click)="upateCountBtnClick($event)"
+                      class="btn btn-outline-primary btn-sm gb-data-selection-update-btn">Update counts</button>
+            </div>
+          </div>
+        </div>
       </md2-accordion-header>
       <gb-selection></gb-selection>
     </md2-accordion-tab>
@@ -21,28 +31,49 @@
     <!-- The 2nd step -->
     <md2-accordion-tab>
       <md2-accordion-header>
-        <span class="gb-data-selection-accordion-header">Step 2: Select the relevant data of your group of
-          subjects</span>
-        <!--<span class="gb-data-selection-accordion-sub-header">-->
-          <!--({{patientCount_2}} {{singularOrPlural('patient', patientCount_2)}},-->
-          <!--with {{observationCount_2}} {{singularOrPlural('observation', observationCount_2)}},-->
-          <!--in {{conceptCount_2}} {{singularOrPlural('concept', conceptCount_2)}} and-->
-          <!--{{studyCount_2}} {{singularOrPlural('study', studyCount_2)}})-->
-        <!--</span>-->
+        <div class="gb-data-selection-accordion-header">
+          <div class="gb-data-selection-accordion-sub-header-1">
+            Step 2: Select the relevant data of your group of
+            subjects
+          </div>
+          <div class="form-inline gb-data-selection-accordion-sub-header-2">
+            <div class="gb-data-selection-accordion-sub-header-3">
+              <span class="gb-data-selection-emphasis-text">{{subjectCount_2}}</span> / {{subjectCount_1}}
+              <span class="gb-data-selection-emphasis-text">subjects</span> {{subjectCountPercentage_2}},
+              <span class="gb-data-selection-emphasis-text">{{observationCount_2}}</span> / {{observationCount_1}}
+              <span class="gb-data-selection-emphasis-text">observations</span> {{observationCountPercentage_2}}
+            </div>
+            <div class="float-right">
+              <button type="button"
+                      (click)="upateCountBtnClick($event)"
+                      class="btn btn-outline-primary btn-sm gb-data-selection-update-btn">Update counts</button>
+            </div>
+          </div>
+        </div>
       </md2-accordion-header>
       <gb-projection></gb-projection>
     </md2-accordion-tab>
 
-    <md2-accordion-tab>
-      <md2-accordion-header>
-        <span class="gb-data-selection-accordion-header">Step 3: Visualize the selected data (optional)</span>
-      </md2-accordion-header>
-      Visualization
-    </md2-accordion-tab>
+    <!--<md2-accordion-tab>-->
+      <!--<md2-accordion-header>-->
+        <!--<span class="gb-data-selection-accordion-header">Step 3: Visualize the selected data (optional)</span>-->
+      <!--</md2-accordion-header>-->
+      <!--Visualization-->
+    <!--</md2-accordion-tab>-->
 
     <md2-accordion-tab>
       <md2-accordion-header>
-        <span class="gb-data-selection-accordion-header">Step 4: Export the selected data (optional)</span>
+        <div class="gb-data-selection-accordion-header">
+          <div class="gb-data-selection-accordion-sub-header-1">
+            Step 3: Export the selected data
+          </div>
+          <div class="form-inline gb-data-selection-accordion-sub-header-2">
+            <div class="gb-data-selection-accordion-sub-header-3">
+              <span class="gb-data-selection-emphasis-text">{{subjectCount_2}} subjects</span>,
+              <span class="gb-data-selection-emphasis-text">{{observationCount_2}} observations</span>
+            </div>
+          </div>
+        </div>
       </md2-accordion-header>
       <gb-export></gb-export>
     </md2-accordion-tab>

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
@@ -19,7 +19,7 @@
             </div>
             <div class="float-right">
               <button type="button"
-                      (click)="upateCountBtnClick($event)"
+                      (click)="updateCounts_1($event)"
                       class="btn btn-outline-primary btn-sm gb-data-selection-update-btn">Update counts</button>
             </div>
           </div>
@@ -45,7 +45,7 @@
             </div>
             <div class="float-right">
               <button type="button"
-                      (click)="upateCountBtnClick($event)"
+                      (click)="updateCounts_2($event)"
                       class="btn btn-outline-primary btn-sm gb-data-selection-update-btn">Update counts</button>
             </div>
           </div>

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.spec.ts
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.spec.ts
@@ -19,6 +19,8 @@ import {ConstraintServiceMock} from '../../services/mocks/constraint.service.moc
 import {routing} from './gb-data-selection.routing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {GenericComponentMock} from '../../services/mocks/generic.component.mock';
+import {QueryService} from '../../services/query.service';
+import {QueryServiceMock} from '../../services/mocks/query.service.mock';
 
 describe('GbDataSelectionComponent', () => {
   let component: GbDataSelectionComponent;
@@ -61,6 +63,10 @@ describe('GbDataSelectionComponent', () => {
         {
           provide: ConstraintService,
           useClass: ConstraintServiceMock
+        },
+        {
+          provide: QueryService,
+          useClass: QueryServiceMock
         }
       ]
     })

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {QueryService} from '../../services/query.service';
 import { FormatHelper } from '../../util/format-helper';
+import { TreeNodeService } from '../../services/tree-node.service';
 
 @Component({
   selector: 'gb-data-selection',
@@ -9,7 +10,7 @@ import { FormatHelper } from '../../util/format-helper';
 })
 export class GbDataSelectionComponent implements OnInit {
 
-  constructor(public queryService: QueryService) {
+  constructor(public queryService: QueryService, public treeNodeService: TreeNodeService) {
   }
 
   ngOnInit() {
@@ -21,6 +22,13 @@ export class GbDataSelectionComponent implements OnInit {
    * @param event
    */
   openAccordion(event) {
+    if (event.index === 1) {
+      // open projection
+      this.queryService.prepareStep2();
+    } else if (event.index === 3) {
+      // open export
+      this.queryService.updateExports();
+    }
   }
 
   /**
@@ -31,6 +39,14 @@ export class GbDataSelectionComponent implements OnInit {
   closeAccordion(event) {
   }
 
+  updateCounts_1(event) {
+    event.stopPropagation();
+    this.queryService.updateCounts_1();
+  }
+
+  updateCounts_2(event) {
+    event.stopPropagation();
+    this.queryService.updateCounts_2();
   }
 
   get subjectCount_0(): string {
@@ -73,14 +89,52 @@ export class GbDataSelectionComponent implements OnInit {
     return FormatHelper.percentage(this.queryService.observationCount_2, this.queryService.observationCount_1);
   }
 
-  updateCounts_1(event) {
-    event.stopPropagation();
-    this.queryService.updateCounts_1();
+  get selectedConcepts(): number {
+    return this.treeNodeService.selectionCount ? this.treeNodeService.selectionCount.concepts : null;
   }
 
-  updateCounts_2(event) {
-    event.stopPropagation();
-    this.queryService.updateCounts_2();
+  get selectedConceptCount(): string {
+    return FormatHelper.formatNumber(this.selectedConcepts);
+  }
+
+  get conceptCount_2(): string {
+    return FormatHelper.formatNumber(this.queryService.conceptCount_2);
+  }
+
+  get selectedConceptCountPercentage(): string {
+    return FormatHelper.percentage(this.selectedConcepts, this.queryService.conceptCount_2);
+  }
+
+  get selectedStudies(): number {
+    return this.treeNodeService.selectionCount ? this.treeNodeService.selectionCount.studies : null;
+  }
+
+  get selectedStudyCount(): string {
+    return FormatHelper.formatNumber(this.selectedStudies);
+  }
+
+  get studyCount_2(): string {
+    return FormatHelper.formatNumber(this.queryService.studyCount_2);
+  }
+
+  get selectedStudyCountPercentage(): string {
+    return FormatHelper.percentage(this.selectedStudies, this.queryService.studyCount_2);
+  }
+
+  get counting_1() {
+    return this.queryService.isUpdating_1;
+  }
+
+  get counting_2() {
+    return this.queryService.isUpdating_2;
+  }
+
+  get dirty_1() {
+    return this.queryService.dirty_1;
+  }
+
+  get dirty_2() {
+    return this.queryService.dirty_2;
   }
 
 }

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
@@ -71,11 +71,15 @@ export class GbDataSelectionComponent implements OnInit {
   }
 
   get observationCountPercentage_1(): string {
-    return '(' + Math.ceil(100 * this.queryService.observationCount_1 / this.queryService.observationCount_0) + '%)';
+    return this.queryService.observationCount_1 !== 0 ?
+      '(' + Math.ceil(100 * this.queryService.observationCount_1 / this.queryService.observationCount_0) + '%)' :
+      '(0%)';
   }
 
   get observationCountPercentage_2(): string {
-    return '(' + Math.ceil(100 * this.queryService.observationCount_2 / this.queryService.observationCount_1) + '%)';
+    return this.queryService.observationCount_2 !== 0 ?
+      '(' + Math.ceil(100 * this.queryService.observationCount_2 / this.queryService.observationCount_1) + '%)' :
+      '(0%)';
   }
 
   updateCounts_1(event) {

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
@@ -1,5 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {QueryService} from '../../services/query.service';
+import { FormatHelper } from '../../util/format-helper';
 
 @Component({
   selector: 'gb-data-selection',
@@ -30,60 +31,46 @@ export class GbDataSelectionComponent implements OnInit {
   closeAccordion(event) {
   }
 
-  numberWithCommas(x: number): string {
-    if (x) {
-      return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    } else {
-      return '0';
-    }
   }
 
   get subjectCount_0(): string {
-    return this.numberWithCommas(this.queryService.subjectCount_0);
+    return FormatHelper.formatNumber(this.queryService.subjectCount_0);
   }
 
   get subjectCount_1(): string {
-    return this.numberWithCommas(this.queryService.subjectCount_1);
+    return FormatHelper.formatNumber(this.queryService.subjectCount_1);
   }
 
   get subjectCount_2(): string {
-    return this.numberWithCommas(this.queryService.subjectCount_2);
+    return FormatHelper.formatNumber(this.queryService.subjectCount_2);
   }
 
   get subjectCountPercentage_1(): string {
-    return this.queryService.subjectCount_1 !== 0 ?
-      '(' + Math.ceil(100 * this.queryService.subjectCount_1 / this.queryService.subjectCount_0) + '%)' :
-      '(0%)';
+      return FormatHelper.percentage(this.queryService.subjectCount_1, this.queryService.subjectCount_0);
   }
 
   get subjectCountPercentage_2(): string {
-    return this.queryService.subjectCount_2 !== 0 ?
-      '(' + Math.ceil(100 * this.queryService.subjectCount_2 / this.queryService.subjectCount_1) + '%)' :
-      '(0%)';
+    return FormatHelper.percentage(this.queryService.subjectCount_2, this.queryService.subjectCount_1);
   }
 
   get observationCount_0(): string {
-    return this.numberWithCommas(this.queryService.observationCount_0);
+    return FormatHelper.formatNumber(this.queryService.observationCount_0);
   }
 
   get observationCount_1(): string {
-    return this.numberWithCommas(this.queryService.observationCount_1);
+    return FormatHelper.formatNumber(this.queryService.observationCount_1);
   }
 
   get observationCount_2(): string {
-    return this.numberWithCommas(this.queryService.observationCount_2);
+    return FormatHelper.formatNumber(this.queryService.observationCount_2);
   }
 
   get observationCountPercentage_1(): string {
-    return this.queryService.observationCount_1 !== 0 ?
-      '(' + Math.ceil(100 * this.queryService.observationCount_1 / this.queryService.observationCount_0) + '%)' :
-      '(0%)';
+    return FormatHelper.percentage(this.queryService.observationCount_1, this.queryService.observationCount_0);
   }
 
   get observationCountPercentage_2(): string {
-    return this.queryService.observationCount_2 !== 0 ?
-      '(' + Math.ceil(100 * this.queryService.observationCount_2 / this.queryService.observationCount_1) + '%)' :
-      '(0%)';
+    return FormatHelper.percentage(this.queryService.observationCount_2, this.queryService.observationCount_1);
   }
 
   updateCounts_1(event) {

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
@@ -1,4 +1,5 @@
 import {Component, OnInit} from '@angular/core';
+import {QueryService} from '../../services/query.service';
 
 @Component({
   selector: 'gb-data-selection',
@@ -7,10 +8,11 @@ import {Component, OnInit} from '@angular/core';
 })
 export class GbDataSelectionComponent implements OnInit {
 
-  constructor() {
+  constructor(public queryService: QueryService) {
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+  }
 
   /**
    * The event handler for the accordion tab open event,
@@ -27,4 +29,53 @@ export class GbDataSelectionComponent implements OnInit {
    */
   closeAccordion(event) {
   }
+
+  upateCountBtnClick(event) {
+    event.stopPropagation(); console.log(event);
+  }
+
+  numberWithCommas(x: number): string {
+    if (x) {
+      return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    } else {
+      return '0';
+    }
+  }
+
+  get subjectCount_0(): string {
+    return this.numberWithCommas(this.queryService.subjectCount_0);
+  }
+
+  get subjectCount_1(): string {
+    return this.numberWithCommas(this.queryService.subjectCount_1);
+  }
+
+  get subjectCount_2(): string {
+    return this.numberWithCommas(this.queryService.subjectCount_2);
+  }
+
+  get subjectCountPercentage_1(): string {
+    return '(' + Math.floor(100 * this.queryService.subjectCount_1 / this.queryService.subjectCount_0) + '%)';
+  }
+
+  get subjectCountPercentage_2(): string {
+    return '(' + Math.floor(100 * this.queryService.subjectCount_2 / this.queryService.subjectCount_1) + '%)';
+  }
+
+  get observationCount_0(): string {
+    return this.numberWithCommas(this.queryService.observationCount_0);
+  }
+
+  get observationCount_1(): string {
+    return this.numberWithCommas(this.queryService.observationCount_1);
+  }
+
+  get observationCountPercentage_1(): string {
+    return '(' + Math.floor(100 * this.queryService.observationCount_1 / this.queryService.observationCount_0) + '%)';
+  }
+
+  get observationCountPercentage_2(): string {
+    return '(' + Math.floor(100 * this.queryService.observationCount_2 / this.queryService.observationCount_1) + '%)';
+  }
+
 }

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
@@ -51,11 +51,15 @@ export class GbDataSelectionComponent implements OnInit {
   }
 
   get subjectCountPercentage_1(): string {
-    return '(' + Math.floor(100 * this.queryService.subjectCount_1 / this.queryService.subjectCount_0) + '%)';
+    return this.queryService.subjectCount_1 !== 0 ?
+      '(' + Math.ceil(100 * this.queryService.subjectCount_1 / this.queryService.subjectCount_0) + '%)' :
+      '(0%)';
   }
 
   get subjectCountPercentage_2(): string {
-    return '(' + Math.floor(100 * this.queryService.subjectCount_2 / this.queryService.subjectCount_1) + '%)';
+    return this.queryService.subjectCount_2 !== 0 ?
+      '(' + Math.ceil(100 * this.queryService.subjectCount_2 / this.queryService.subjectCount_1) + '%)' :
+      '(0%)';
   }
 
   get observationCount_0(): string {

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.ts
@@ -30,10 +30,6 @@ export class GbDataSelectionComponent implements OnInit {
   closeAccordion(event) {
   }
 
-  upateCountBtnClick(event) {
-    event.stopPropagation(); console.log(event);
-  }
-
   numberWithCommas(x: number): string {
     if (x) {
       return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -70,12 +66,26 @@ export class GbDataSelectionComponent implements OnInit {
     return this.numberWithCommas(this.queryService.observationCount_1);
   }
 
+  get observationCount_2(): string {
+    return this.numberWithCommas(this.queryService.observationCount_2);
+  }
+
   get observationCountPercentage_1(): string {
-    return '(' + Math.floor(100 * this.queryService.observationCount_1 / this.queryService.observationCount_0) + '%)';
+    return '(' + Math.ceil(100 * this.queryService.observationCount_1 / this.queryService.observationCount_0) + '%)';
   }
 
   get observationCountPercentage_2(): string {
-    return '(' + Math.floor(100 * this.queryService.observationCount_2 / this.queryService.observationCount_1) + '%)';
+    return '(' + Math.ceil(100 * this.queryService.observationCount_2 / this.queryService.observationCount_1) + '%)';
+  }
+
+  updateCounts_1(event) {
+    event.stopPropagation();
+    this.queryService.updateCounts_1();
+  }
+
+  updateCounts_2(event) {
+    event.stopPropagation();
+    this.queryService.updateCounts_2();
   }
 
 }

--- a/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.css
+++ b/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.css
@@ -31,15 +31,13 @@
   margin-bottom: 3px;
   margin-right: 7px;
   max-width: 100%;
-  font-size: small;
+  font-size: medium;
   padding: 0.3em 0.3em 0.3em 0.5em;
 }
 
 /* save btn */
 .gb-data-selection-overview-panel-save-btn {
-  margin-bottom: 3px;
-  margin-right: 7px;
-  width: 100%;
+  margin: .1em;
 }
 .gb-data-selection-overview-panel-save-btn:hover {
   background-color: rgba(51, 156, 144, 0.7);
@@ -50,8 +48,7 @@
 
 /* import btn */
 .gb-data-selection-overview-panel-import-btn {
-  margin-right: 7px;
-  width: 100%;
+  margin: .1em;
 }
 .gb-data-selection-overview-panel-import-btn:hover {
   background-color: rgba(51, 156, 144, 0.7);

--- a/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.html
+++ b/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.html
@@ -11,13 +11,6 @@
     <button class="btn btn-outline-primary btn-sm gb-data-selection-overview-panel-save-btn"
             (click)="saveQuery()"
             type="button">Save query</button>
-    <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-    <input id="queryFileUpload"
-           type="file"
-           style="display: none"/>
-    <button class="btn btn-outline-primary btn-sm gb-data-selection-overview-panel-import-btn"
-            (click)="importQuery()"
-            type="button">Import query</button>
   </div>
 
   <p-messages [(value)]="queryService.alertMessages"></p-messages>

--- a/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.html
+++ b/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.html
@@ -11,6 +11,7 @@
     <button class="btn btn-outline-primary btn-sm gb-data-selection-overview-panel-save-btn"
             (click)="saveQuery()"
             type="button">Save query</button>
+    <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
     <input id="queryFileUpload"
            type="file"
            style="display: none"/>

--- a/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.html
+++ b/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.html
@@ -2,72 +2,21 @@
   <p-tabMenu [model]="items" [activeItem]="activeItem"></p-tabMenu>
 
   <!-- The data selection overview panel -->
-  <div *ngIf="isDataSelection" class="gb-data-selection-overview-panel">
-    <div class="row">
-      <div class="col-3">
-        <button type="button"
-                (click)="updateQuery()"
-                class="btn btn-secondary btn-sm gb-data-selection-control-btn
-                gb-data-selection-overview-panel-update-btn">
-          Update</button>
-      </div>
-      <div class="col-5">
-        <div class="row">
-          <span *ngIf="!isLoadingObservationCount_2">
-            {{patientCount_2}} {{singularOrPlural('subject', subject)}}
-          </span>
-          <span *ngIf="isLoadingObservationCount_2">
-            <i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i> subjects
-          </span>
-        </div>
-        <div class="row">
-          <span *ngIf="!isLoadingObservationCount_2">
-            {{observationCount_2}} {{singularOrPlural('observation', observationCount_2)}}
-          </span>
-          <span *ngIf="isLoadingObservationCount_2">
-            <i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i> observations
-          </span>
-        </div>
-        <div class="row">
-          <span *ngIf="!isLoadingConceptCount_2">
-            {{conceptCount_2}} {{singularOrPlural('concept', conceptCount_2)}}
-          </span>
-          <span *ngIf="isLoadingConceptCount_2">
-            <i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i> concepts
-          </span>
-        </div>
-        <div class="row">
-          <span *ngIf="!isLoadingStudyCount_2">
-            {{studyCount_2}} {{singularOrPlural('study', studyCount_2)}}
-          </span>
-          <span *ngIf="isLoadingStudyCount_2">
-            <i class="fa fa-spinner fa-pulse fa-1x fa-fw"></i> studies
-          </span>
-        </div>
-      </div>
-      <div class="col-4">
-        <div class="row">
-          <input id="queryName" type="text"
-                 class="form-control gb-data-selection-overview-panel-input"
-                 placeholder="Query name"
-                 (drop)="preventNodeDrop($event)"
-                 [(ngModel)]="queryName" >
-        </div>
-        <div class="row">
-          <button class="btn btn-outline-primary btn-sm gb-data-selection-overview-panel-save-btn"
-                  (click)="saveQuery()"
-                  type="button">Save query</button>
-        </div>
-        <div class="row">
-          <input id="queryFileUpload"
-                 type="file"
-                 style="display: none"/>
-          <button class="btn btn-outline-primary btn-sm gb-data-selection-overview-panel-import-btn"
-                  (click)="importQuery()"
-                  type="button">Import query</button>
-        </div>
-      </div>
-    </div>
+  <div *ngIf="isDataSelection" class="container form-inline gb-data-selection-overview-panel">
+    <input id="queryName" type="text"
+           class="form-control gb-data-selection-overview-panel-input"
+           placeholder="Query name"
+           (drop)="preventNodeDrop($event)"
+           [(ngModel)]="queryName" >
+    <button class="btn btn-outline-primary btn-sm gb-data-selection-overview-panel-save-btn"
+            (click)="saveQuery()"
+            type="button">Save query</button>
+    <input id="queryFileUpload"
+           type="file"
+           style="display: none"/>
+    <button class="btn btn-outline-primary btn-sm gb-data-selection-overview-panel-import-btn"
+            (click)="importQuery()"
+            type="button">Import query</button>
   </div>
 
   <p-messages [(value)]="queryService.alertMessages"></p-messages>

--- a/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.ts
+++ b/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.ts
@@ -18,12 +18,10 @@ export class GbNavBarComponent implements OnInit {
   public isAnalysis = false;
 
   public queryName: string;
-  private isUploadListenerNotAdded: boolean;
 
   constructor(private router: Router,
               public queryService: QueryService) {
     this.queryName = '';
-    this.isUploadListenerNotAdded = true;
   }
 
   ngOnInit() {
@@ -79,16 +77,6 @@ export class GbNavBarComponent implements OnInit {
     event.preventDefault();
   }
 
-  importQuery() {
-    let uploadElm = document.getElementById('queryFileUpload');
-    if (this.isUploadListenerNotAdded) {
-      uploadElm
-        .addEventListener('change', this.queryFileUpload.bind(this), false);
-      this.isUploadListenerNotAdded = false;
-    }
-    uploadElm.click();
-  }
-
   saveQuery() {
     let name = this.queryName ? this.queryName.trim() : '';
     let queryNameIsValid = name !== '';
@@ -100,61 +88,6 @@ export class GbNavBarComponent implements OnInit {
       this.queryService.alertMessages.length = 0;
       this.queryService.alertMessages.push({severity: 'warn', summary: summary, detail: ''});
     }
-  }
-
-  updateQuery() {
-    // console.log(this.queryService);
-    this.queryService.updateCounts_1(true);
-  }
-
-  queryFileUpload(event) {
-    let reader = new FileReader();
-    let file = event.target.files[0];
-    reader.onload = (function (e) {
-      if (file.type === 'application/json') {
-        let json = JSON.parse(e.target['result']);
-        let pathArray = null;
-        // If the json is of standard format
-        if (json['patientsQuery'] || json['observationsQuery']) {
-          this.constraintService.putQuery(json);
-        } else if (json['paths']) {
-          pathArray = json['paths'];
-        } else if (json.constructor === Array) {
-          pathArray = json;
-        }
-
-        if (pathArray) {
-          let query = {
-            'name': 'imported temporary query',
-            'patientsQuery': {'type': 'true'},
-            'observationsQuery': {
-              data: pathArray
-            }
-          };
-          this.constraintService.putQuery(query);
-          this.constraintService.alert('Imported concept selection in Step 2.', '', 'info');
-        }
-      } else if (file.type === 'text/plain' ||
-        file.type === 'text/tab-separated-values' ||
-        file.type === 'text/csv' ||
-        file.type === '') {
-        // we assume the text contains a list of subject Ids
-        let query = {
-          'name': 'imported temporary query',
-          'patientsQuery': {
-            'type': 'patient_set',
-            'subjectIds': e.target['result'].split('\n')
-          },
-          'observationsQuery': {}
-        };
-        this.constraintService.putQuery(query);
-        this.constraintService.alert('Imported subject selection in Step 1.', '', 'info');
-      }
-
-      // reset the input path so that it will take the same file again
-      document.getElementById('queryFileUpload')['value'] = '';
-    }).bind(this);
-    reader.readAsText(file);
   }
 }
 

--- a/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.ts
+++ b/src/app/modules/gb-nav-bar-module/gb-nav-bar.component.ts
@@ -70,16 +70,6 @@ export class GbNavBarComponent implements OnInit {
     this._activeItem = value;
   }
 
-  public singularOrPlural(noun: string, number: string) {
-    if (number === '1' || number === '0') {
-      return noun;
-    } else if (noun === 'study') {
-      return 'studies';
-    } else {
-      return noun + 's';
-    }
-  }
-
   /**
    * Prevent the default behavior of node drop
    * @param event
@@ -165,46 +155,6 @@ export class GbNavBarComponent implements OnInit {
       document.getElementById('queryFileUpload')['value'] = '';
     }).bind(this);
     reader.readAsText(file);
-  }
-
-  numberWithCommas(x: number): string {
-    if (x) {
-      return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    } else {
-      return '0';
-    }
-  }
-
-  get patientCount_2(): string {
-    return this.numberWithCommas(this.queryService.patientCount_2);
-  }
-
-  get isLoadingPatientCount_2(): boolean {
-    return this.queryService.isLoadingPatientCount_2;
-  }
-
-  get observationCount_2(): string {
-    return this.numberWithCommas(this.queryService.observationCount_2);
-  }
-
-  get isLoadingObservationCount_2(): boolean {
-    return this.queryService.isLoadingObservationCount_2;
-  }
-
-  get conceptCount_2(): string {
-    return this.numberWithCommas(this.queryService.conceptCount_2);
-  }
-
-  get isLoadingConceptCount_2(): boolean {
-    return this.queryService.isLoadingConceptCount_2;
-  }
-
-  get studyCount_2(): string {
-    return this.numberWithCommas(this.queryService.studyCount_2);
-  }
-
-  get isLoadingStudyCount_2(): boolean {
-    return this.queryService.isLoadingStudyCount_2;
   }
 }
 

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.css
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.css
@@ -6,11 +6,22 @@
   margin-bottom: 3px;
 }
 
-.gb-query-filter-btn {
+.gb-query-panel-clear-btn {
   font-size: small;
   padding-top: 0.2em;
   padding-bottom: 0.2em;
   color: gray;
+}
+
+.gb-query-panel-import-btn {
+  font-size: small;
+  padding-top: 0.2em;
+  padding-bottom: 0.2em;
+}
+
+.gb-query-panel-sort-btn-container {
+  margin-top: 6px;
+  margin-bottom: -10px;
 }
 
 /*

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.html
@@ -19,7 +19,7 @@
   </div>
 
 
-  <div class="container gb-query-panel-sort-btn-container">
+  <div *ngIf="queries.length > 0" class="container gb-query-panel-sort-btn-container">
     <div class="float-right">
       <button pButton class="ui-button-secondary gb-query-sort-btn" type="button"
               (click)="sortByName()"

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.html
@@ -40,6 +40,7 @@
       <div *ngIf="query['visible']"
            class="gb-query-panel">
         <p-panel [collapsed]="query['collapsed']"
+                 (keypress)="onQueryPanelKeyEnter($event, query)"
                  (click)="onQueryPanelClick(query)">
           <p-header>
             <div class="ui-helper-clearfix">

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.html
@@ -7,10 +7,19 @@
                     placeholder="Search queries"
                     (onClear)="onFiltering($event)"
                     (completeMethod)="onFiltering($event)"></p-autoComplete>
-    <button class="btn btn-secondary btn-sm gb-query-filter-btn"
+    <button class="btn btn-secondary btn-sm gb-query-panel-clear-btn"
             (click)="clearFilter()"
             type="button">clear</button>
+    <input id="queryFileUpload"
+           type="file"
+           style="display: none"/>
+    <button class="btn btn-outline-primary gb-query-panel-import-btn"
+            (click)="importQuery()"
+            type="button">import query</button>
+  </div>
 
+
+  <div class="container gb-query-panel-sort-btn-container">
     <div class="float-right">
       <button pButton class="ui-button-secondary gb-query-sort-btn" type="button"
               (click)="sortByName()"
@@ -29,8 +38,8 @@
               icon="icon-sort-subscription">
       </button>
     </div>
+    <br><br>
   </div>
-  <br><br>
 
 
   <!-- queries -->

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.ts
@@ -12,13 +12,75 @@ export class GbQueriesComponent implements OnInit {
 
   searchTerm = '';
   collapsed = false;
+  private isUploadListenerNotAdded: boolean;
 
   constructor(public treeNodeService: TreeNodeService,
               private queryService: QueryService,
               private element: ElementRef) {
+    this.isUploadListenerNotAdded = true;
   }
 
   ngOnInit() {
+  }
+
+  importQuery() {
+    let uploadElm = document.getElementById('queryFileUpload');
+    if (this.isUploadListenerNotAdded) {
+      uploadElm
+        .addEventListener('change', this.queryFileUpload.bind(this), false);
+      this.isUploadListenerNotAdded = false;
+    }
+    uploadElm.click();
+  }
+
+  queryFileUpload(event) {
+    let reader = new FileReader();
+    let file = event.target.files[0];
+    reader.onload = (function (e) {
+      if (file.type === 'application/json') {
+        let json = JSON.parse(e.target['result']);
+        let pathArray = null;
+        // If the json is of standard format
+        if (json['patientsQuery'] || json['observationsQuery']) {
+          this.queryService.restoreQuery(json);
+        } else if (json['paths']) {
+          pathArray = json['paths'];
+        } else if (json.constructor === Array) {
+          pathArray = json;
+        }
+
+        if (pathArray) {
+          let query = {
+            'name': 'imported temporary query',
+            'patientsQuery': {'type': 'true'},
+            'observationsQuery': {
+              data: pathArray
+            }
+          };
+          this.queryService.restoreQuery(query);
+          this.queryService.alert('Imported concept selection in Step 2.', '', 'info');
+        }
+      } else if (file.type === 'text/plain' ||
+        file.type === 'text/tab-separated-values' ||
+        file.type === 'text/csv' ||
+        file.type === '') {
+        // we assume the text contains a list of subject Ids
+        let query = {
+          'name': 'imported temporary query',
+          'patientsQuery': {
+            'type': 'patient_set',
+            'subjectIds': e.target['result'].split('\n')
+          },
+          'observationsQuery': {}
+        };
+        this.queryService.restoreQuery(query);
+        this.queryService.alert('Imported subject selection in Step 1.', '', 'info');
+      }
+
+      // reset the input path so that it will take the same file again
+      document.getElementById('queryFileUpload')['value'] = '';
+    }).bind(this);
+    reader.readAsText(file);
   }
 
   // query panel collapse and expansion

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.ts
@@ -1,6 +1,5 @@
-import {Component, OnInit, ElementRef, AfterViewInit} from '@angular/core';
+import {Component, OnInit, ElementRef} from '@angular/core';
 import {TreeNodeService} from '../../../../services/tree-node.service';
-import {DropMode} from '../../../../models/drop-mode';
 import {Query} from '../../../../models/query';
 import {QueryService} from '../../../../services/query.service';
 
@@ -9,10 +8,9 @@ import {QueryService} from '../../../../services/query.service';
   templateUrl: './gb-queries.component.html',
   styleUrls: ['./gb-queries.component.css']
 })
-export class GbQueriesComponent implements OnInit, AfterViewInit {
+export class GbQueriesComponent implements OnInit {
 
   searchTerm = '';
-  observer: MutationObserver;
   collapsed = false;
 
   constructor(public treeNodeService: TreeNodeService,
@@ -21,31 +19,6 @@ export class GbQueriesComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
-  }
-
-  ngAfterViewInit() {
-    this.observer = new MutationObserver(this.update.bind(this));
-    const config = {
-      attributes: false,
-      subtree: true,
-      childList: true,
-      characterData: false
-    };
-
-    this.observer.observe(this.element.nativeElement, config);
-  }
-
-  update() {
-    let panels = this.element.nativeElement.querySelectorAll('.gb-query-panel');
-    let index = 0;
-    for (let panel of panels) {
-      let correspondingQuery = this.queryService.queries[index];
-      panel.addEventListener('dragstart', (function () {
-        correspondingQuery['dropMode'] = DropMode.Query;
-        this.constraintService.selectedNode = correspondingQuery;
-      }).bind(this));
-      index++;
-    }
   }
 
   // query panel collapse and expansion
@@ -112,7 +85,18 @@ export class GbQueriesComponent implements OnInit, AfterViewInit {
     query['nameEditable'] = true;
   }
 
+  onQueryPanelKeyEnter(event, query) {
+    if (event.key === 'Enter' && query['nameEditable']) {
+      query['nameEditable'] = false;
+      const queryObject = {
+        name: query['name']
+      };
+      this.queryService.updateQuery(query['id'], queryObject);
+    }
+  }
+
   onQueryPanelClick(query) {
+    // console.log('on query click, ', query);
     // Save the query if its name has been modified
     if (query['nameEditable']) {
       query['nameEditable'] = false;

--- a/src/app/services/mocks/query.service.mock.ts
+++ b/src/app/services/mocks/query.service.mock.ts
@@ -1,4 +1,7 @@
+import {Query} from '../../models/query';
+
 export class QueryServiceMock {
+  private _queries: Query[] = [];
   /*
     * ------ variables used in the Selection accordion in Data Selection ------
     */
@@ -61,5 +64,13 @@ export class QueryServiceMock {
 
   set exportFormats(value: Array<object>) {
     this._exportFormats = value;
+  }
+
+  get queries(): Query[] {
+    return this._queries;
+  }
+
+  set queries(value: Query[]) {
+    this._queries = value;
   }
 }

--- a/src/app/services/mocks/query.service.mock.ts
+++ b/src/app/services/mocks/query.service.mock.ts
@@ -50,6 +50,8 @@ export class QueryServiceMock {
   public updateCounts_1() {}
   public updateCounts_2() {}
 
+  public updateStudyAndConceptCounts() {}
+
   get isLoadingExportFormats(): boolean {
     return this._isLoadingExportFormats;
   }

--- a/src/app/services/mocks/query.service.mock.ts
+++ b/src/app/services/mocks/query.service.mock.ts
@@ -2,23 +2,23 @@ export class QueryServiceMock {
   /*
     * ------ variables used in the Selection accordion in Data Selection ------
     */
-  private _inclusionPatientCount = 0;
-  private _exclusionPatientCount = 0;
-  // the number of patients selected in the first step
-  private _patientCount_1 = 0;
-  // the number of observations from the selected patients in the first step
+  private _inclusionSubjectCount = 0;
+  private _exclusionSubjectCount = 0;
+  // the number of subjects selected in the first step
+  private _subjectCount_1 = 0;
+  // the number of observations from the selected subjects in the first step
   private _observationCount_1 = 0;
-  // the number of concepts from the selected patients in the first step
+  // the number of concepts from the selected subjects in the first step
   private _conceptCount_1 = 0;
-  // the number of studies from the selected patients in the first step
+  // the number of studies from the selected subjects in the first step
   private _studyCount_1 = 0;
 
   /*
    * ------ variables used in the Projection accordion in Data Selection ------
    */
-  // the number of patients further refined in the second step
-  // _patientCount_2 < or = _patientCount_1
-  private _patientCount_2 = 0;
+  // the number of subjects further refined in the second step
+  // _subjectCount_2 < or = _subjectCount_1
+  private _subjectCount_2 = 0;
   // the number of observations further refined in the second step
   // _observationCount_2 < or = _observationCount_1
   private _observationCount_2 = 0;

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -7,7 +7,7 @@ import {ConstraintService} from './constraint.service';
 import {AppConfig} from '../config/app.config';
 import {Step} from '../models/step';
 
-type LoadingState = 'loading' | 'complete';
+export type LoadingState = 'loading' | 'complete';
 
 /**
  * This service concerns with

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -6,6 +6,7 @@ import {Query} from '../models/query';
 import {ConstraintService} from './constraint.service';
 import {AppConfig} from '../config/app.config';
 import {Step} from '../models/step';
+import { Constraint } from '../models/constraints/constraint';
 
 export type LoadingState = 'loading' | 'complete';
 
@@ -45,7 +46,9 @@ export class QueryService {
   private _inclusionSubjectCount = 0;
   private _exclusionSubjectCount = 0;
   // flag indicating if the counts in the first step are being updated
-  private _isUpdating_1 = false;
+  private _isUpdating_1 = true;
+  private _inclusionObservationCount = 0;
+  private _exclusionObservationCount = 0;
   // the number of subjects selected in the first step
   private _subjectCount_1 = 0;
   // the number of observations from the selected subjects in the first step
@@ -93,24 +96,21 @@ export class QueryService {
   /*
    * ------ variables used in the 2nd step (Projection) accordion in Data Selection ------
    */
-  // flag indicating if the counts in the first step are being updated
+  // flag indicating if the counts in the second step are being updated
   private _isUpdating_2 = false;
   // the number of subjects further refined in the second step
   // _subjectCount_2 < or = _subjectCount_1
   private _subjectCount_2 = 0;
-  private _isLoadingSubjectCount_2 = true; // the flag indicating if the count is being loaded
   // the number of observations further refined in the second step
   // _observationCount_2 could be <, > or = _observationCount_1
   private _observationCount_2 = 0;
-  private _isLoadingObservationCount_2 = true; // the flag indicating if the count is being loaded
   // the number of concepts further refined in the second step
   // _conceptCount_2 could be <, > or = _conceptCount_1
   private _conceptCount_2 = 0;
-  private _isLoadingConceptCount_2 = true; // the flag indicating if the count is being loaded
   // the number of studies further refined in the second step
   // _studyCount_2 could be <, > or = _studyCount_1
   private _studyCount_2 = 0;
-  private _isLoadingStudyCount_2 = true; // the flag indicating if the count is being loaded
+  private _isLoadingTreeCounts_2 = false; // the flag indicating if the count is being loaded
   // the codes of the concepts selected in the second step
   private _conceptCodes_2 = [];
   // the codes of the studies selected in the first step
@@ -145,6 +145,14 @@ export class QueryService {
    */
   private _syncFinalCounts: boolean;
 
+  /**
+   * Flag if the current visible counts are out of sync with the current subject query.
+   */
+  private _dirty_1 = false;
+  /**
+   * Flag if the current visible counts are out of sync with the current projection query.
+   */
+  private _dirty_2 = false;
 
   constructor(private appConfig: AppConfig,
               private resourceService: ResourceService,
@@ -180,152 +188,84 @@ export class QueryService {
       );
   }
 
-  /**
-   * update the subject, observation, concept and study counts in the first step
-   */
-  public updateCounts_1(initialUpdate?: boolean) {
-    this.isUpdating_1 = true;
-    /*
-     * ====== function updateCounts_1 starts ======
-     */
-    // add time stamp to the queue,
-    // only when the time stamp is at the end of the queue, the count is updated
-    this.clearQueueOfCalls(this.queueOfCalls_1);
-    let timestamp = new Date();
-    this.queueOfCalls_1.push(timestamp.getMilliseconds());
-    // set the flags
-    this.loadingStateInclusion = 'loading';
-    this.loadingStateExclusion = 'loading';
-    this.loadingStateTotal = 'loading';
-    // also update the flags for the counts in the 2nd step
-    this.isLoadingSubjectCount_2 = true;
-    this.isLoadingObservationCount_2 = true;
-    this.isLoadingConceptCount_2 = true;
-    this.isLoadingStudyCount_2 = true;
+  public mergeInclusionAndExclusionCounts(initialUpdate?: boolean) {
+      this.subjectCount_1 = this.inclusionSubjectCount - this.exclusionSubjectCount;
+      this.observationCount_1 = this.inclusionObservationCount - this.exclusionObservationCount;
+      if (initialUpdate) {
+          this.subjectCount_0 = this.subjectCount_1;
+          this.observationCount_0 = this.observationCount_1;
+      }
+      this.isUpdating_1 = false;
+      this.loadingStateTotal = 'complete';
+  }
+
+  public updateInclusionCounts(constraint: Constraint, initialUpdate?: boolean) {
     /*
      * Inclusion constraint subject count
      */
-    let inclusionConstraint = this.constraintService.generateInclusionConstraint();
-    this.resourceService.getCounts(inclusionConstraint)
+    this.resourceService.getCounts(constraint)
       .subscribe(
-        countResponse => {
-          const index = this.queueOfCalls_1.indexOf(timestamp.getMilliseconds());
-          if (index !== -1 && index === (this.queueOfCalls_1.length - 1)) {
-            this.inclusionSubjectCount = countResponse['patientCount'];
-            this.loadingStateInclusion = 'complete';
-            if (this.loadingStateTotal !== 'complete' && this.loadingStateExclusion === 'complete') {
-              this.subjectCount_1 = this.inclusionSubjectCount - this.exclusionSubjectCount;
-              this.loadingStateTotal = 'complete';
-              this.observationCount_1 = countResponse['observationCount'];
-              // Update the final counts: subjects and observations
-              if (this.syncFinalCounts || initialUpdate) {
-                this.subjectCount_0 = this.subjectCount_1;
-                this.observationCount_0 = this.observationCount_1;
-                this.subjectCount_2 = this.subjectCount_1;
-                this.observationCount_2 = this.observationCount_1;
-                this.isLoadingSubjectCount_2 = false;
-                this.isLoadingObservationCount_2 = false;
-              }
-            }
-          }
-        },
-        err => {
+          countResponse => {
+        this.inclusionSubjectCount = countResponse['patientCount'];
+        this.inclusionObservationCount = countResponse['observationCount'];
+        this.loadingStateInclusion = 'complete';
+        if (this.loadingStateTotal !== 'complete' && this.loadingStateExclusion === 'complete') {
+          this.mergeInclusionAndExclusionCounts(initialUpdate);
+        }
+      },
+      err => {
           console.error(err);
           this.loadingStateInclusion = 'complete';
-        }
-      );
+          this.loadingStateTotal = 'complete';
+      }
+    );
+  }
 
+  public updateExclusionCounts(constraint: Constraint, initialUpdate?: boolean) {
     /*
      * Exclusion constraint subject count
      * (Only execute the exclusion constraint if it has non-empty children)
      */
-    if (this.constraintService.rootExclusionConstraint.hasNonEmptyChildren()) {
-      let exclusionConstraint = this.constraintService.generateExclusionConstraint();
-      this.resourceService.getCounts(exclusionConstraint)
+    this.resourceService.getCounts(constraint)
         .subscribe(
-          countResponse => {
-            const index = this.queueOfCalls_1.indexOf(timestamp.getMilliseconds());
-            if (index !== -1 && index === (this.queueOfCalls_1.length - 1)) {
-              this.exclusionSubjectCount = countResponse['patientCount'];
-              this.loadingStateExclusion = 'complete';
-              if (this.loadingStateTotal !== 'complete' && this.loadingStateInclusion === 'complete') {
-                this.subjectCount_1 = this.inclusionSubjectCount - this.exclusionSubjectCount;
-                this.loadingStateTotal = 'complete';
-                this.observationCount_1 = countResponse['observationCount'];
-                // Update the final counts: subjects and observations
-                if (this.syncFinalCounts || initialUpdate) {
-                  this.subjectCount_0 = this.subjectCount_1;
-                  this.subjectCount_2 = this.subjectCount_1;
-                  this.observationCount_2 = this.observationCount_1;
-                  this.isLoadingSubjectCount_2 = false;
-                  this.isLoadingObservationCount_2 = false;
-                }
-              }
-            }
-          },
-          err => {
-            console.error(err);
-            this.loadingStateExclusion = 'complete';
-          }
-        );
-    } else {
-      this.exclusionSubjectCount = 0;
-      this.loadingStateExclusion = 'complete';
-    }
-    /*
-     * update concept and study counts in the first step
-     */
-    const selectionConstraint = this.constraintService.generateSelectionConstraint();
-    this.resourceService.getCountsPerStudyAndConcept(selectionConstraint)
-      .subscribe(
-        (countObj) => {
-          const index = this.queueOfCalls_1.indexOf(timestamp.getMilliseconds());
-          if (index !== -1 && index === (this.queueOfCalls_1.length - 1)) {
-            let studyKeys = [];
-            let conceptKeys = [];
-            this.conceptCountMap_1 = {};
-            this.studyCountMap_1 = {};
-            for (let studyKey in countObj) {
-              studyKeys.push(studyKey);
-              let _concepts_ = countObj[studyKey];
-              let patientCountUnderThisStudy = 0;
-              let observationCountUnderThisStudy = 0;
-              for (let _concept_ in _concepts_) {
-                if (conceptKeys.indexOf(_concept_) === -1) {
-                  conceptKeys.push(_concept_);
-                }
-                this.conceptCountMap_1[_concept_] = countObj[studyKey][_concept_];
-                patientCountUnderThisStudy += this.conceptCountMap_1[_concept_]['patientCount'];
-                observationCountUnderThisStudy += this.conceptCountMap_1[_concept_]['observationCount'];
-              }
-              this.studyCountMap_1[studyKey] = {
-                patientCount: patientCountUnderThisStudy,
-                observationCount: observationCountUnderThisStudy
-              };
-            }
-            this.conceptCount_1 = conceptKeys.length;
-            this.studyCount_1 = studyKeys.length;
-            this.conceptCodes_1 = conceptKeys;
-            // Update the final counts: concepts and studies
-            if (this.syncFinalCounts || initialUpdate) {
-              this.conceptCount_2 = this.conceptCount_1;
-              this.studyCount_2 = this.studyCount_1;
-              this.conceptCodes_2 = this.conceptCodes_1;
-              this.isLoadingConceptCount_2 = false;
-              this.isLoadingStudyCount_2 = false;
-            }
-            /*
-             * update subject counts on tree nodes on the left side
-             */
-            this.treeNodeService.updateTreeNodeCounts(this.studyCountMap_1, this.conceptCountMap_1);
-            /*
-             * update the tree nodes in the 2nd step
-             */
-            this.updateTreeNodes_2();
+            countResponse => {
+          this.exclusionSubjectCount = countResponse['patientCount'];
+          this.exclusionObservationCount = countResponse['observationCount'];
+          this.loadingStateExclusion = 'complete';
+          if (this.loadingStateTotal !== 'complete' && this.loadingStateInclusion === 'complete') {
+            this.mergeInclusionAndExclusionCounts(initialUpdate);
           }
         },
-        err => console.error(err)
+        err => {
+            console.error(err);
+            this.loadingStateExclusion = 'complete';
+            this.loadingStateTotal = 'complete';
+        }
       );
+  }
+
+  /**
+   * update the patient, observation, concept and study counts in the first step
+   */
+  public updateCounts_1(initialUpdate?: boolean) {
+    this.loadingStateTotal = 'loading';
+    this.isUpdating_1 = true;
+    this.dirty_1 = false;
+    /*
+     * ====== function updateCounts_1 starts ======
+     */
+    this.loadingStateInclusion = 'loading';
+    let hasExclusionConstraints = this.constraintService.rootExclusionConstraint.hasNonEmptyChildren();
+    if (hasExclusionConstraints) {
+      this.loadingStateExclusion = 'loading';
+      let exclusionConstraint = this.constraintService.generateExclusionConstraint();
+      this.updateExclusionCounts(exclusionConstraint, initialUpdate);
+    } else {
+      this.exclusionSubjectCount = 0;
+      this.exclusionObservationCount = 0;
+    }
+    let inclusionConstraint = this.constraintService.generateInclusionConstraint();
+    this.updateInclusionCounts(inclusionConstraint, initialUpdate);
     /*
      * ====== function updateCounts_1 ends ======
      */
@@ -372,84 +312,92 @@ export class QueryService {
     }
   }
 
+  public updatePatientsAndObservationsCounts(constraint: Constraint) {
+    // set flags to true indicating the counts are being loaded
+    this.isUpdating_2 = true;
+    // update the patient count and observation count in the 2nd step
+    this.resourceService.getCounts(constraint)
+      .subscribe(
+          (countResponse) => {
+          this.subjectCount_2 = countResponse['patientCount'];
+          this.observationCount_2 = countResponse['observationCount'];
+          this.isUpdating_2 = false;
+        },
+        err => console.error(err)
+    );
+  }
+
+  public updateStudyAndConceptCounts(constraint: Constraint) {
+    // set flags to true indicating the counts are being loaded
+    this.isLoadingTreeCounts_2 = true;
+    // update the concept and study counts in the 2nd step
+    this.resourceService.getCountsPerStudyAndConcept(constraint)
+      .subscribe(
+          (countObj) => {
+        let studyKeys = [];
+        let conceptKeys = [];
+        this.conceptCountMap_1 = {};
+        this.studyCountMap_1 = {};
+        for (let studyKey in countObj) {
+            studyKeys.push(studyKey);
+            let _concepts_ = countObj[studyKey];
+            let patientCountUnderThisStudy = 0;
+            let observationCountUnderThisStudy = 0;
+            for (let _concept_ in _concepts_) {
+                if (conceptKeys.indexOf(_concept_) === -1) {
+                    conceptKeys.push(_concept_);
+                }
+                this.conceptCountMap_1[_concept_] = countObj[studyKey][_concept_];
+                patientCountUnderThisStudy += this.conceptCountMap_1[_concept_]['patientCount'];
+                observationCountUnderThisStudy += this.conceptCountMap_1[_concept_]['observationCount'];
+            }
+            this.studyCountMap_1[studyKey] = {
+                patientCount: patientCountUnderThisStudy,
+                observationCount: observationCountUnderThisStudy
+            };
+        }
+        this.conceptCount_1 = conceptKeys.length;
+        this.studyCount_1 = studyKeys.length;
+        this.conceptCodes_1 = conceptKeys;
+
+        this.conceptCount_2 = this.conceptCount_1;
+        this.studyCount_2 = this.studyCount_1;
+        this.conceptCodes_2 = this.conceptCodes_1;
+        this.isLoadingTreeCounts_2 = false;
+        this.updateTreeNodes_2();
+      },
+      err => console.error(err)
+    );
+  }
+
   /**
-   * update the subject, observation, concept and study counts in the second step
+   * update the concept and study counts as preparation for the second step
    */
-  public updateCounts_2() {
+  public prepareStep2() {
     /*
      * ====== function updateCounts_2 starts ======
      */
-    if (!this.isUpdating_1) {
-      // add time stamp to the queue,
-      // only when the time stamp is at the end of the queue, the count is updated
-      this.clearQueueOfCalls(this.queueOfCalls_2);
-      let timestamp = new Date();
-      this.queueOfCalls_2.push(timestamp.getMilliseconds());
-      // set flags to true indicating the counts are being loaded
-      this.isLoadingSubjectCount_2 = true;
-      this.isLoadingObservationCount_2 = true;
-      this.isLoadingConceptCount_2 = true;
-      this.isLoadingStudyCount_2 = true;
-
-      this.query = null; // clear query
-      const selectionConstraint = this.constraintService.generateSelectionConstraint();
-      const projectionConstraint = this.constraintService.generateProjectionConstraint();
-
-      let combo = new CombinationConstraint();
-      combo.addChild(selectionConstraint);
-      combo.addChild(projectionConstraint);
-
-      // update the subject count and observation count in the 2nd step
-      this.resourceService.getCounts(combo)
-        .subscribe(
-          (countResponse) => {
-            const index = this.queueOfCalls_2.indexOf(timestamp.getMilliseconds());
-            if (index !== -1 && index === (this.queueOfCalls_2.length - 1)) {
-              this.subjectCount_2 = countResponse['patientCount'];
-              this.isLoadingSubjectCount_2 = false;
-              this.observationCount_2 = countResponse['observationCount'];
-              this.isLoadingObservationCount_2 = false;
-            }
-          },
-          err => console.error(err)
-        );
-
-      // update the concept and study counts in the 2nd step
-      this.resourceService.getCountsPerStudyAndConcept(combo)
-        .subscribe(
-          (countObj) => {
-            const index = this.queueOfCalls_2.indexOf(timestamp.getMilliseconds());
-            if (index !== -1 && index === (this.queueOfCalls_2.length - 1)) {
-              let studies = [];
-              let concepts = [];
-              for (let study in countObj) {
-                studies.push(study);
-                let _concepts_ = countObj[study];
-                for (let _concept_ in _concepts_) {
-                  if (concepts.indexOf(_concept_) === -1) {
-                    concepts.push(_concept_);
-                  }
-                }
-              }
-              this.conceptCount_2 = concepts.length;
-              this.studyCount_2 = studies.length;
-              this.conceptCodes_2 = concepts;
-              this.isLoadingConceptCount_2 = false;
-              this.isLoadingStudyCount_2 = false;
-            }
-          },
-          err => console.error(err)
-        );
-      this.updateExports();
-    } else {
-      window.setTimeout((function () {
-        this.updateCounts_2();
-      }).bind(this), 500);
-    }
-
+    this.query = null; // clear query
+    const selectionConstraint = this.constraintService.generateSelectionConstraint();
+    // this.updatePatientsAndObservationsCounts(selectionConstraint);
+    this.updateStudyAndConceptCounts(selectionConstraint);
     /*
      * ====== function updateCounts_2 ends ======
      */
+  }
+
+  /**
+   * Update subject and observations counts in step 2 (variable selection).
+   */
+  public updateCounts_2() {
+      this.dirty_2 = false;
+      this.query = null; // clear query
+      const selectionConstraint = this.constraintService.generateSelectionConstraint();
+      const projectionConstraint = this.constraintService.generateProjectionConstraint();
+      let constraint = new CombinationConstraint();
+      constraint.addChild(selectionConstraint);
+      constraint.addChild(projectionConstraint);
+      this.updatePatientsAndObservationsCounts(constraint);
   }
 
   public updateExports() {
@@ -539,7 +487,7 @@ export class QueryService {
     this.constraintService.clearSelectionConstraint();
     let selectionConstraint = this.constraintService.generateConstraintFromConstraintObject(query['patientsQuery']);
     this.constraintService.restoreSelectionConstraint(selectionConstraint);
-    this.updateCounts_1(false);
+    this.updateCounts_1();
     this.updateCounts_2();
     const summary = 'Query "' + query['name'] + '" imported';
     this.alert(summary, '', 'info');
@@ -601,6 +549,22 @@ export class QueryService {
 
   set observationCount_0(value: number) {
     this._observationCount_0 = value;
+  }
+
+  get inclusionObservationCount(): number {
+    return this._inclusionObservationCount;
+  }
+
+  set inclusionObservationCount(value: number) {
+    this._inclusionObservationCount = value;
+  }
+
+  get exclusionObservationCount(): number {
+    return this._exclusionObservationCount;
+  }
+
+  set exclusionObservationCount(value: number) {
+    this._exclusionObservationCount = value;
   }
 
   get subjectCount_1(): number {
@@ -731,36 +695,12 @@ export class QueryService {
     this._query = value;
   }
 
-  get isLoadingSubjectCount_2(): boolean {
-    return this._isLoadingSubjectCount_2;
+  get isLoadingTreeCounts_2(): boolean {
+    return this._isLoadingTreeCounts_2;
   }
 
-  set isLoadingSubjectCount_2(value: boolean) {
-    this._isLoadingSubjectCount_2 = value;
-  }
-
-  get isLoadingObservationCount_2(): boolean {
-    return this._isLoadingObservationCount_2;
-  }
-
-  set isLoadingObservationCount_2(value: boolean) {
-    this._isLoadingObservationCount_2 = value;
-  }
-
-  get isLoadingConceptCount_2(): boolean {
-    return this._isLoadingConceptCount_2;
-  }
-
-  set isLoadingConceptCount_2(value: boolean) {
-    this._isLoadingConceptCount_2 = value;
-  }
-
-  get isLoadingStudyCount_2(): boolean {
-    return this._isLoadingStudyCount_2;
-  }
-
-  set isLoadingStudyCount_2(value: boolean) {
-    this._isLoadingStudyCount_2 = value;
+  set isLoadingTreeCounts_2(value: boolean) {
+    this._isLoadingTreeCounts_2 = value;
   }
 
   get queueOfCalls_1(): Array<number> {
@@ -850,4 +790,21 @@ export class QueryService {
   set isUpdating_2(value: boolean) {
     this._isUpdating_2 = value;
   }
+
+  get dirty_1(): boolean {
+    return this._dirty_1;
+  }
+
+  set dirty_1(value: boolean) {
+    this._dirty_1 = value;
+  }
+
+  get dirty_2(): boolean {
+    return this._dirty_2;
+  }
+
+  set dirty_2(value: boolean) {
+    this._dirty_2 = value;
+  }
+
 }

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -179,7 +179,7 @@ export class QueryService {
   /**
    * update the subject, observation, concept and study counts in the first step
    */
-  public updateCounts_1(continuousUpdate?: boolean, initialUpdate?: boolean) {
+  public updateCounts_1(initialUpdate?: boolean) {
     /*
      * ====== function updateCounts_1 starts ======
      */
@@ -314,13 +314,9 @@ export class QueryService {
              */
             this.treeNodeService.updateTreeNodeCounts(this.studyCountMap_1, this.conceptCountMap_1);
             /*
-             * update the export info
-             */
-            this.updateExports();
-            /*
              * update the tree nodes in the 2nd step
              */
-            this.updateTreeNodes_2(continuousUpdate);
+            this.updateTreeNodes_2();
           }
         },
         err => console.error(err)
@@ -336,7 +332,7 @@ export class QueryService {
    * only when the tree nodes are completely loaded can we start updating
    * the counts in the 2nd step
    */
-  private updateTreeNodes_2(continuousUpdate: boolean) {
+  private updateTreeNodes_2() {
     if (this.treeNodeService.isTreeNodeLoadingComplete()) {
 
       // Only update the tree in the 2nd step when the user changes sth. in the 1st step
@@ -363,9 +359,6 @@ export class QueryService {
       }
 
       this.query = null;
-      if (continuousUpdate) {
-        this.updateCounts_2();
-      }
     } else {
       window.setTimeout((function () {
         this.updateTreeNodes_2();

--- a/src/app/util/format-helper.ts
+++ b/src/app/util/format-helper.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class FormatHelper {
+
+    public static singularOrPlural(noun: string, number: string) {
+        if (number === '1' || number === '0') {
+            return noun;
+        } else if (noun === 'study') {
+            return 'studies';
+        } else {
+            return noun + 's';
+        }
+    }
+
+    public static formatNumber(x: number): string {
+        if (x) {
+            return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        } else {
+            return '0';
+        }
+    }
+
+    public static percentage(part: number, total: number): string {
+        if (total === null || total === 0) {
+            return '';
+        } else {
+            let perc = part ? (part / total) * 100 : 0;
+            return `(${perc.toFixed(0)}%)`;
+        }
+    }
+
+}


### PR DESCRIPTION
- Move formatting logic to separate helper class.
- Remove duplicate loading state enum type.
- Refactor query counts functionality:
  - mark state as dirty after modifying constraints or variable selection;
  - display waiting indicators when retrieving counts;
  - split long functions;
- Fix bug with 'select all' (adds to instead of overrides current selection)