### PR TITLE
Create patient set before fetching tree counts for patient selection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,116 @@
 # GlowingBear
 [![Build Status](https://travis-ci.org/thehyve/glowing-bear.svg?branch=master)](https://travis-ci.org/thehyve/glowing-bear/branches)
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.0.0.
+A cohort selection user interface for [TranSMART].
 
-## Development server
+
+## Development
+
+This project was generated with [Angular CLI] version 1.0.0.
+
+### Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
-## Code scaffolding
+### Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive/pipe/service/class/module`.
 
-## Build
+### Build
 
 Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `-prod` flag for a production build.
 
-## Running unit tests
+### Running unit tests
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io), run `ng test --code-coverage` to test with generated coverage documents, which are located in the coverage folder.
+Run `ng test` to execute the unit tests via [Karma], run `ng test --code-coverage` to test with generated coverage documents, which are located in the coverage folder.
 
-## Running end-to-end tests
+### Running end-to-end tests
 
-For e2e test we use [Protractor](http://www.protractortest.org/) in combination with the [cucumber-js](https://github.com/cucumber/cucumber-js) framework.
+For e2e test we use [Protractor] in combination with the [cucumber-js] framework.
 To install protractor run `npm install -g protractor`. 
-To run the tests you need to have an up to dated version of chrome installed and the application running. by default on `localhost:8080`
-to run al tests: `protractor`
-To run specific feature files: `protractor --specs=e2e/features/name-of.feature`
+To run the tests you need to have an up to dated version of chrome installed and the TranSMART application running, by default on `localhost:8080`.
+To run all tests: `protractor`.
+To run specific feature files: `protractor --specs=e2e/features/name-of.feature`.
 
-## Further help
+### Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+
+## Publishing
+
+We use Gradle to create bundles that are suitable for deployment:
+```bash
+# Create a tar bundle in build/distributions
+gradle assemble
+
+# Publish the bundle to Nexus
+gradle publish
+```
+
+## Deployment
+
+Published snapshot bundles are available in the `snapshots` repository
+on https://repo.thehyve.nl with id `nl.thehyve:glowing-bear:0.0.1-SNAPSNOT:tar`.
+
+Untar the archive in a directory where it can be served by a web server,
+e.g., [Apache] or [nginx].
+
+### Configuration
+
+The application can be configured by changing the `env.json` and `config.*.json`
+files in `app/config`.
+
+Example `env.json`:
+```json
+{
+  "env": "prod"
+}
+```
+Example `config.prod.json`:
+```json
+{
+  "api-url": "https://transmart.thehyve.net",
+  "api-version": "v2",
+  "app-url": "https://glowingbear.thehyve.net",
+  "tree-node-counts-update": true,
+  "autosave-subject-sets": false
+}
+```
+
+Supported properties in the `config.*.json` files:
+
+| Property                  | Default   | Description |
+|:------------------------- |:--------- |:----------- |
+| `api-url`                 |           | URL of the TranSMART API to connect to. |
+| `api-version`             | `v2`      | TranSMART API version. Only `v2` is supported. |
+| `app-url`                 |           | URL where the Glowing Bear is accessible for the user. |
+| `tree-node-counts-update` | `true`    | Fetch counts for study nodes in step 2 of Data Selection. |
+| `autosave-subject-sets`   | `false`   | Persist subject selection as subject set automatically. |
+
+
+## License
+
+Copyright &copy; 2017&ndash;2018 &nbsp; The Hyve B.V.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the [GNU General Public License](LICENSE)
+along with this program. If not, see https://www.gnu.org/licenses/.
+
+
+[tranSMART]: https://github.com/thehyve/transmart-core
+[Angular CLI]: https://github.com/angular/angular-cli
+[Protractor]: http://www.protractortest.org
+[Karma]: https://karma-runner.github.io
+[cucumber-js]: https://github.com/cucumber/cucumber-js
+[nginx]: https://nginx.org
+[Apache]: https://httpd.apache.org

--- a/src/app/config/app.config.ts
+++ b/src/app/config/app.config.ts
@@ -14,9 +14,11 @@ export class AppConfig {
 
   /**
    * Use to get the data found in the second file (config file)
+   * if present; returns default value otherwise.
    */
-  public getConfig(key: any) {
-    return this.config[key];
+  public getConfig(key: any, defaultValue: any = null) {
+      let value = this.config[key];
+      return value != null ? value : defaultValue;
   }
 
   /**

--- a/src/app/modules/gb-data-selection-module/accordion-components/gb-export/gb-export.component.ts
+++ b/src/app/modules/gb-data-selection-module/accordion-components/gb-export/gb-export.component.ts
@@ -101,7 +101,8 @@ export class GbExportComponent implements OnInit {
       }
     }
     if (elements.length > 0) {
-      const selectionConstraint = this.constraintService.generateSelectionConstraint();
+      const selectionConstraint = this.queryService.patientSet_1 ?
+          this.queryService.patientSet_1 : this.constraintService.generateSelectionConstraint();
       const projectionConstraint = this.constraintService.generateProjectionConstraint();
       let combo = new CombinationConstraint();
       combo.addChild(selectionConstraint);

--- a/src/app/services/endpoint.service.ts
+++ b/src/app/services/endpoint.service.ts
@@ -9,7 +9,7 @@ export class EndpointService {
 
   constructor(private appConfig: AppConfig) {
     let apiUrl = appConfig.getConfig('api-url');
-    let apiVersion = appConfig.getConfig('api-version');
+    let apiVersion = appConfig.getConfig('api-version', 'v2');
     let appUrl = appConfig.getConfig('app-url');
     if (this.isValidUrl(apiUrl) && this.isValidUrl(appUrl)) {
       this.endpoint = new Endpoint(apiUrl, apiVersion, appUrl);

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -444,30 +444,6 @@ export class QueryService {
      */
   }
 
-  // private updatePatientSet(timeStamp) {
-  //   const selectionConstraint = this.constraintService.generateSelectionConstraint();
-  //   this.resourceService.createPatientSet(name, selectionConstraint)
-  //     .subscribe(
-  //       patientSetObj => {
-  //         this.patientSet_1 = new PatientSetConstraint();
-  //         this.patientSet_1.setSize = patientSetObj['setSize'];
-  //         this.patientSet_1.id = patientSetObj['id'];
-  //         this.patientSet_1.status = patientSetObj['status'];
-  //         /*
-  //         * update concept and study counts in the first step
-  //         */
-  //         this.resourceService.getCountsPerStudyAndConcept(this.patientSet_1)
-  //           .subscribe(
-  //             (countObj) => {
-  //               this.updateConceptsAndStudies(timeStamp);
-  //             },
-  //             err => this.handle_error(err)
-  //           );
-  //       },
-  //       err => this.handle_error(err)
-  //     );
-  // }
-
   /**
    * ------------------------------------------------- END: step 1 ---------------------------------------------------
    */

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -7,6 +7,9 @@ import {ConstraintService} from './constraint.service';
 import {Step} from '../models/step';
 import {PatientSetConstraint} from '../models/constraints/patient-set-constraint';
 import {FormatHelper} from '../utilities/FormatHelper';
+import {PatientSetResponse} from '../models/patient-set-response';
+import {Constraint} from '../models/constraints/constraint';
+import {AppConfig} from '../config/app.config';
 
 type LoadingState = 'loading' | 'complete';
 
@@ -45,6 +48,8 @@ export class QueryService {
    */
   private _inclusionSubjectCount = 0;
   private _exclusionSubjectCount = 0;
+  private _inclusionObservationCount = 0;
+  private _exclusionObservationCount = 0;
   /*
    * when step 1 constraints are changed, whether to call updateCounts_1 immediately,
    * used in gb-constraint-component
@@ -134,15 +139,22 @@ export class QueryService {
    * Flag indicating if to relay the counts in the current step to the next
    */
   private _countsRelay: boolean;
+  /**
+   * Flag indicating if the subject selection of step 1 should be automatically
+   * saved as subject set in the backend. If true, that subject set is used as the subject constraint
+   * for step 2.
+   */
+  private _autosaveSubjectSets: boolean;
 
-
-  constructor(private resourceService: ResourceService,
+  constructor(private appConfig: AppConfig,
+              private resourceService: ResourceService,
               private treeNodeService: TreeNodeService,
               private constraintService: ConstraintService) {
     this.instantCountsUpdate_1 = false;
     this.instantCountsUpdate_2 = false;
-    this.treeNodeCountsUpdate = true;
+    this.treeNodeCountsUpdate = appConfig.getConfig('tree-node-counts-update', true);
     this.countsRelay = false;
+    this.autosaveSubjectSets = appConfig.getConfig('autosave-subject-sets', false);
     this.loadQueries();
   }
 
@@ -180,7 +192,23 @@ export class QueryService {
       );
   }
 
-  /**
+  private mergeInclusionAndExclusionCounts(initialUpdate?: boolean) {
+    if (this.autosaveSubjectSets) {
+      // Not computing the counts based on inclusion and exclusion counts,
+      // but using the subject set and counts per study concept response instead.
+      return;
+    }
+    this.subjectCount_1 = this.inclusionSubjectCount - this.exclusionSubjectCount;
+    this.observationCount_1 = this.inclusionObservationCount - this.exclusionObservationCount;
+    if (initialUpdate) {
+      this.subjectCount_0 = this.subjectCount_1;
+      this.observationCount_0 = this.observationCount_1;
+    }
+    this.isUpdating_1 = false;
+    this.loadingStateTotal = 'complete';
+  }
+
+    /**
    * ------------------------------------------------- BEGIN: step 1 -------------------------------------------------
    */
   // Relay counts from step 1 to step 2
@@ -208,16 +236,10 @@ export class QueryService {
           const index = this.queueOfCalls_1.indexOf(timeStamp.getMilliseconds());
           if (index !== -1 && index === (this.queueOfCalls_1.length - 1)) {
             this.inclusionSubjectCount = countResponse['patientCount'];
+            this.inclusionObservationCount = countResponse['observationCount'];
             this.loadingStateInclusion = 'complete';
             if (this.loadingStateTotal !== 'complete' && this.loadingStateExclusion === 'complete') {
-              this.subjectCount_1 = this.inclusionSubjectCount - this.exclusionSubjectCount;
-              this.loadingStateTotal = 'complete';
-              this.isUpdating_1 = false;
-              this.observationCount_1 = countResponse['observationCount'];
-              if (initialUpdate) {
-                this.subjectCount_0 = this.subjectCount_1;
-                this.observationCount_0 = this.observationCount_1;
-              }
+              this.mergeInclusionAndExclusionCounts(initialUpdate);
               // relay the current counts to the next step: subjects and observations
               this.relayCounts_1_2();
             }
@@ -239,16 +261,10 @@ export class QueryService {
             const index = this.queueOfCalls_1.indexOf(timeStamp.getMilliseconds());
             if (index !== -1 && index === (this.queueOfCalls_1.length - 1)) {
               this.exclusionSubjectCount = countResponse['patientCount'];
+              this.exclusionObservationCount = countResponse['observationCount'];
               this.loadingStateExclusion = 'complete';
               if (this.loadingStateTotal !== 'complete' && this.loadingStateInclusion === 'complete') {
-                this.subjectCount_1 = this.inclusionSubjectCount - this.exclusionSubjectCount;
-                this.loadingStateTotal = 'complete';
-                this.isUpdating_1 = false;
-                this.observationCount_1 = countResponse['observationCount'];
-                if (initialUpdate) {
-                  this.subjectCount_0 = this.subjectCount_1;
-                  this.observationCount_0 = this.observationCount_1;
-                }
+                this.mergeInclusionAndExclusionCounts(initialUpdate);
                 // relay the current counts to the next step: subjects and observations
                 this.relayCounts_1_2();
               }
@@ -265,23 +281,51 @@ export class QueryService {
     }
   }
 
-  private updateConceptsAndStudies(timeStamp: Date) {
-    const selectionConstraint = this.constraintService.generateSelectionConstraint();
-    this.resourceService.getCountsPerStudyAndConcept(selectionConstraint)
+  private updateSubjectCount(subjectCount: number, initialUpdate?: boolean) {
+    this.subjectCount_1 = subjectCount;
+    if (initialUpdate) {
+      this.subjectCount_0 = this.subjectCount_1;
+    }
+  }
+
+  private updateObservationCount(observationCount: number, initialUpdate?: boolean) {
+    this.observationCount_1 = observationCount;
+    if (initialUpdate) {
+      this.observationCount_0 = this.observationCount_1;
+    }
+    this.isUpdating_1 = false;
+    this.loadingStateTotal = 'complete';
+  }
+
+  private updateConceptsAndStudiesForSubjectSet(
+      response: PatientSetResponse, selectionConstraint: Constraint, timeStamp: Date, initialUpdate: boolean) {
+    let constraint: Constraint;
+    if (response) {
+      this.patientSet_1 = new PatientSetConstraint();
+      this.patientSet_1.id = response.id;
+      this.updateSubjectCount(response.setSize, initialUpdate);
+      constraint = this.patientSet_1;
+    } else {
+      constraint = selectionConstraint;
+    }
+    this.resourceService.getCountsPerStudyAndConcept(constraint)
       .subscribe(
         (conceptCountObj) => {
           const index = this.queueOfCalls_1.indexOf(timeStamp.getMilliseconds());
           if (index !== -1 && index === (this.queueOfCalls_1.length - 1)) {
             // construct concept count map in the 1st step
+            let observationCount = 0;
             this.conceptCountMap_1 = {};
             for (let studyKey in conceptCountObj) {
               for (let _concept_ in conceptCountObj[studyKey]) {
                 this.conceptCountMap_1[_concept_] = conceptCountObj[studyKey][_concept_];
+                observationCount += conceptCountObj[studyKey][_concept_]['observationCount'];
               }
             }
+            this.updateObservationCount(observationCount, initialUpdate);
             // construct study count map in the 1st step if flag is true
             if (this.treeNodeCountsUpdate) {
-              this.resourceService.getCountsPerStudy(selectionConstraint)
+              this.resourceService.getCountsPerStudy(constraint)
                 .subscribe(
                   (studyCountObj) => {
                     this.studyCountMap_1 = studyCountObj;
@@ -298,6 +342,21 @@ export class QueryService {
         },
         err => this.handle_error(err)
       );
+  }
+
+  private updateConceptsAndStudies(timeStamp: Date, initialUpdate: boolean) {
+    const selectionConstraint = this.constraintService.generateSelectionConstraint();
+    if (this.autosaveSubjectSets) {
+      // save a subject set for the subject selection, compute tree counts using that subject set
+      this.resourceService.savePatientSet('temp', selectionConstraint).subscribe((response) => {
+          this.updateConceptsAndStudiesForSubjectSet(response, selectionConstraint, timeStamp, initialUpdate);
+        },
+        err => this.handle_error(err)
+      );
+    } else {
+      // compute tree counts without saving a subject set
+      this.updateConceptsAndStudiesForSubjectSet(null, selectionConstraint, timeStamp, initialUpdate);
+    }
   }
 
   /**
@@ -375,7 +434,7 @@ export class QueryService {
     /*
      * update concept and study counts in the first step
      */
-    this.updateConceptsAndStudies(timeStamp);
+    this.updateConceptsAndStudies(timeStamp, initialUpdate);
     /*
      * create patient set for the current query in step 1
      */
@@ -471,7 +530,8 @@ export class QueryService {
   }
 
   public updateExports() {
-    const selectionConstraint = this.constraintService.generateSelectionConstraint();
+    const selectionConstraint = this.patientSet_1 ?
+        this.patientSet_1 : this.constraintService.generateSelectionConstraint();
     const projectionConstraint = this.constraintService.generateProjectionConstraint();
     let combo = new CombinationConstraint();
     combo.addChild(selectionConstraint);
@@ -629,6 +689,22 @@ export class QueryService {
 
   set exclusionSubjectCount(value: number) {
     this._exclusionSubjectCount = value;
+  }
+
+  get inclusionObservationCount(): number {
+    return this._inclusionObservationCount;
+  }
+
+  set inclusionObservationCount(value: number) {
+    this._inclusionObservationCount = value;
+  }
+
+  get exclusionObservationCount(): number {
+    return this._exclusionObservationCount;
+  }
+
+  set exclusionObservationCount(value: number) {
+    this._exclusionObservationCount = value;
   }
 
   get subjectCount_0(): number {
@@ -797,6 +873,14 @@ export class QueryService {
 
   set countsRelay(value: boolean) {
     this._countsRelay = value;
+  }
+
+  get autosaveSubjectSets(): boolean {
+    return this._autosaveSubjectSets;
+  }
+
+  set autosaveSubjectSets(value: boolean) {
+    this._autosaveSubjectSets = value;
   }
 
   get step(): Step {

--- a/src/app/services/resource.service.ts
+++ b/src/app/services/resource.service.ts
@@ -382,7 +382,7 @@ export class ResourceService {
 
   // -------------------------------------- patient set calls --------------------------------------
   savePatientSet(name: string, constraint: Constraint): Observable<PatientSetResponse> {
-    const urlPart = `patient_sets?name=${name}`;
+    const urlPart = `patient_sets?name=${name}&reuse=true`;
     const body = constraint.toQueryObject();
     return this.postCall(urlPart, body, null);
   }


### PR DESCRIPTION
Save the subject selection of step 1 automatically as subject set in the backend. That subject set is used as the subject constraint for counts in step 2 and for export.