### PR TITLE
Fix subject id import for dos/windows line breaks.

### DIFF
--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.ts
@@ -37,7 +37,7 @@ export class GbQueriesComponent implements OnInit {
 
   processSubjectIdsUpload(fileContents: string, fileName: string): Query {
     // we assume the text contains a list of subject Ids
-    let subjectIds: string[] = fileContents.split(/(\r\n)+/)
+    let subjectIds: string[] = fileContents.split(/(\r?\n)+/)
       .map(id => id.trim())
       .filter(id => id.length > 0);
     let query = new Query(null, fileName);

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-queries/gb-queries.component.ts
@@ -35,12 +35,27 @@ export class GbQueriesComponent implements OnInit {
     uploadElm.click();
   }
 
+  processSubjectIdsUpload(fileContents: string, fileName: string): Query {
+    // we assume the text contains a list of subject Ids
+    let subjectIds: string[] = fileContents.split(/(\r\n)+/)
+      .map(id => id.trim())
+      .filter(id => id.length > 0);
+    let query = new Query(null, fileName);
+    query.patientsQuery = {
+      'type': 'patient_set',
+      'subjectIds': subjectIds
+    };
+    query.observationsQuery = {data: null};
+    return query;
+  }
+
   queryFileUpload(event) {
     let reader = new FileReader();
-    let file = event.target.files[0];
-    reader.onload = (function (e) {
+    let file: File = event.target.files[0];
+    reader.onload = (function (e: Event) {
+      let contents: string = e.target['result'] as string;
       if (file.type === 'application/json') {
-        let _json = JSON.parse(e.target['result']);
+        let _json = JSON.parse(contents);
         let pathArray = null;
         // If the json is of standard format
         if (_json['patientsQuery'] || _json['observationsQuery']) {
@@ -54,11 +69,9 @@ export class GbQueriesComponent implements OnInit {
           pathArray = _json;
         }
         if (pathArray) {
-          let query = {
-            'name': file.name,
-            'observationsQuery': {
+          let query = new Query(null, file.name);
+          query.observationsQuery = {
               data: pathArray
-            }
           };
           this.queryService.restoreQuery(query);
         }
@@ -66,15 +79,7 @@ export class GbQueriesComponent implements OnInit {
         file.type === 'text/tab-separated-values' ||
         file.type === 'text/csv' ||
         file.type === '') {
-        // we assume the text contains a list of subject Ids
-        let query = {
-          'name': file.name,
-          'patientsQuery': {
-            'type': 'patient_set',
-            'subjectIds': e.target['result'].split('\n')
-          },
-          'observationsQuery': {}
-        };
+        let query = this.processSubjectIdsUpload(contents, file.name);
         this.queryService.restoreQuery(query);
       }
 


### PR DESCRIPTION
Fix issue with import of subject ids that contains Windows line breaks (`\r\n`).
Also skip empty lines.

Fixes [NTRDEV-320](https://jira.thehyve.nl/secure/RapidBoard.jspa?rapidView=110&view=detail&selectedIssue=NTRDEV-320).