### PR TITLE
Keep publishing unde nl/thehyve/glowing-bear/ folder.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ publishing {
     }
     publications {
         maven(MavenPublication) {
+            artifactId 'glowing-bear'
             artifact distTar // Publish the output of the distTar task
         }
     }


### PR DESCRIPTION
Even when repository folder named differently from glowing-bear.
It's true for bamboo builds that pull source code to folder like TM-GBFRONT-JOB1.