### PR TITLE
Remove ng2-simple-timer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "font-awesome": "^4.7.0",
     "md2": "^0.0.29",
     "moment": "^2.22.2",
-    "ng2-simple-timer": "^1.3.1",
     "primeng": "^5.2.3",
     "roboto-fontface": "^0.8.0",
     "rxjs": "^5.1.0",

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.module.ts
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.module.ts
@@ -22,7 +22,6 @@ import {
   TooltipModule,
   MessagesModule, PickListModule, PaginatorModule
 } from 'primeng/primeng';
-import {SimpleTimer} from 'ng2-simple-timer';
 import {GbProjectionComponent} from './accordion-components/gb-projection/gb-projection.component';
 import {GbSubjectSetConstraintComponent} from './constraint-components/gb-subject-set-constraint/gb-subject-set-constraint.component';
 import {GbPedigreeConstraintComponent} from './constraint-components/gb-pedigree-constraint/gb-pedigree-constraint.component';
@@ -53,9 +52,6 @@ import {TableModule} from 'primeng/table';
   ],
   exports: [
     RouterModule
-  ],
-  providers: [
-    SimpleTimer
   ],
   declarations: [
     GbDataSelectionComponent,

--- a/src/app/modules/gb-export-module/gb-export.component.spec.ts
+++ b/src/app/modules/gb-export-module/gb-export.component.spec.ts
@@ -9,7 +9,6 @@ import {FormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
 import {ResourceService} from '../../services/resource.service';
 import {ResourceServiceMock} from '../../services/mocks/resource.service.mock';
-import {SimpleTimer} from 'ng2-simple-timer';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {AppConfig} from '../../config/app.config';
 import {AppConfigMock} from '../../config/app.config.mock';
@@ -37,7 +36,6 @@ describe('GbExportComponent', () => {
         MessagesModule
       ],
       providers: [
-        SimpleTimer,
         {
           provide: AppConfig,
           useClass: AppConfigMock

--- a/src/app/modules/gb-export-module/gb-export.component.ts
+++ b/src/app/modules/gb-export-module/gb-export.component.ts
@@ -1,28 +1,32 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {ResourceService} from '../../services/resource.service';
-import {SimpleTimer} from 'ng2-simple-timer';
 import {ExportJob} from '../../models/export-models/export-job';
 import {AppConfig} from '../../config/app.config';
 import {ExportService} from '../../services/export.service';
 import {ExportDataType} from '../../models/export-models/export-data-type';
+import Timer = NodeJS.Timer;
 
 @Component({
   selector: 'gb-export',
   templateUrl: './gb-export.component.html',
   styleUrls: ['./gb-export.component.css']
 })
-export class GbExportComponent implements OnInit {
+export class GbExportComponent implements OnInit, OnDestroy {
+
+  private timer: Timer;
 
   constructor(private appConfig: AppConfig,
               private exportService: ExportService,
-              public resourceService: ResourceService,
-              private timer: SimpleTimer) {
-    this.exportService.updateExportJobs();
-    this.timer.newTimer('30sec', 30);
-    this.timer.subscribe('30sec', () => this.exportService.updateExportJobs());
+              public resourceService: ResourceService) {
   }
 
   ngOnInit() {
+    this.exportService.updateExportJobs();
+    this.timer = setInterval(() => this.exportService.updateExportJobs(), 30 * 1000);
+  }
+
+  ngOnDestroy() {
+    clearInterval(this.timer);
   }
 
   createExportJob() {

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -5,7 +5,7 @@
     "module": "es2015",
     "target": "es2016",
     "baseUrl": "",
-    "types": []
+    "types": ["node"]
   },
   "exclude": [
     "test.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -422,10 +422,6 @@ angular-auth-oidc-client@4.1.0:
   dependencies:
     jsrsasign "8.0.3"
 
-angular2-uuid@*:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/angular2-uuid/-/angular2-uuid-1.1.1.tgz#72f03cd532b7f40032eb1ecfb9f8457384be956e"
-
 ansi-escapes@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
@@ -5271,12 +5267,6 @@ next-tick@1:
 ng2-mock-component@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ng2-mock-component/-/ng2-mock-component-0.1.1.tgz#5980e8887523754f855febc0c11f6c20f016d865"
-
-ng2-simple-timer@^1.3.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/ng2-simple-timer/-/ng2-simple-timer-1.3.3.tgz#4b54f83b65496c367f98318280ba63cd912b235f"
-  dependencies:
-    angular2-uuid "*"
 
 no-case@^2.2.0:
   version "2.3.2"


### PR DESCRIPTION
The `ng2-simple-timer` library was only imported to provide an injectable timer, while Javascript/Node already provide timers that suffice.