### PR TITLE
Add updating of subjectSets before running the export job

### DIFF
--- a/src/app/models/constraint-models/subject-set-constraint.ts
+++ b/src/app/models/constraint-models/subject-set-constraint.ts
@@ -20,7 +20,6 @@ export class SubjectSetConstraint extends Constraint {
   private _id: number;
   private _description: string;
   private _errorMessage: string;
-  private _requestConstraints: Constraint;
 
   constructor(subjectSet?: SubjectSet) {
     super();
@@ -91,11 +90,4 @@ export class SubjectSetConstraint extends Constraint {
     this._errorMessage = value;
   }
 
-  get requestConstraints(): Constraint {
-    return this._requestConstraints;
-  }
-
-  set requestConstraints(value: Constraint) {
-    this._requestConstraints = value;
-  }
 }

--- a/src/app/models/constraint-models/subject-set-constraint.ts
+++ b/src/app/models/constraint-models/subject-set-constraint.ts
@@ -20,7 +20,7 @@ export class SubjectSetConstraint extends Constraint {
   private _id: number;
   private _description: string;
   private _errorMessage: string;
-  private _requestConstraints: string;
+  private _requestConstraints: Constraint;
 
   constructor(subjectSet?: SubjectSet) {
     super();
@@ -91,11 +91,11 @@ export class SubjectSetConstraint extends Constraint {
     this._errorMessage = value;
   }
 
-  get requestConstraints(): string {
+  get requestConstraints(): Constraint {
     return this._requestConstraints;
   }
 
-  set requestConstraints(value: string) {
+  set requestConstraints(value: Constraint) {
     this._requestConstraints = value;
   }
 }

--- a/src/app/services/constraint.service.ts
+++ b/src/app/services/constraint.service.ts
@@ -255,6 +255,32 @@ export class ConstraintService {
   }
 
   /**
+   * Generate a new constraint based on a current selection in the 1st step
+   * only if subjectSetConstraint is not up to date with the selection
+   * @returns {Constraint}
+   */
+  public subjectSetConstraintIfDifferentInCurrentSelection(): Constraint {
+    let currentSelectionConstraint = this.generateSelectionConstraint();
+    if (this.subjectSetConstraint.requestConstraints !== currentSelectionConstraint) {
+      return currentSelectionConstraint;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Update the subjectSetConstraint when a new subject set is created
+   * @param {number} id
+   * @param {Constraint} updatedConstraint
+   */
+  public updateSubjectSetConstraint(id: number, updatedConstraint: Constraint) {
+    let newSubjectSetConstraint = new SubjectSetConstraint();
+    newSubjectSetConstraint.id = id;
+    newSubjectSetConstraint.requestConstraints = updatedConstraint;
+    this.subjectSetConstraint = newSubjectSetConstraint;
+  }
+
+  /**
    * Clear the patient constraints
    */
   public clearConstraint_1() {

--- a/src/app/services/constraint.service.ts
+++ b/src/app/services/constraint.service.ts
@@ -255,32 +255,6 @@ export class ConstraintService {
   }
 
   /**
-   * Generate a new constraint based on a current selection in the 1st step
-   * only if subjectSetConstraint is not up to date with the selection
-   * @returns {Constraint}
-   */
-  public subjectSetConstraintIfDifferentInCurrentSelection(): Constraint {
-    let currentSelectionConstraint = this.generateSelectionConstraint();
-    if (this.subjectSetConstraint.requestConstraints !== currentSelectionConstraint) {
-      return currentSelectionConstraint;
-    } else {
-      return null;
-    }
-  }
-
-  /**
-   * Update the subjectSetConstraint when a new subject set is created
-   * @param {number} id
-   * @param {Constraint} updatedConstraint
-   */
-  public updateSubjectSetConstraint(id: number, updatedConstraint: Constraint) {
-    let newSubjectSetConstraint = new SubjectSetConstraint();
-    newSubjectSetConstraint.id = id;
-    newSubjectSetConstraint.requestConstraints = updatedConstraint;
-    this.subjectSetConstraint = newSubjectSetConstraint;
-  }
-
-  /**
    * Clear the patient constraints
    */
   public clearConstraint_1() {

--- a/src/app/services/export.service.ts
+++ b/src/app/services/export.service.ts
@@ -60,23 +60,13 @@ export class ExportService {
               summary = 'Export job "' + name + '" is created.';
               MessageHelper.alert('success', summary);
               this.exportJobName = '';
-              if (this.constraintService.subjectSetConstraint) {
-                this.runExportJobWithSubjectSetConstraint(newJob)
-                  .then(() => {
-                    resolve(true);
-                  })
-                  .catch(err => {
-                    reject(err)
-                  });
-              } else {
-                this.runExportJob(newJob)
-                  .then(() => {
-                    resolve(true);
-                  })
-                  .catch(err => {
-                    reject(err)
-                  });
-              }
+              this.runExportJob(newJob)
+                .then(() => {
+                  resolve(true);
+                })
+                .catch(err => {
+                  reject(err)
+                });
             },
             (err: HttpErrorResponse) => {
               ErrorHelper.handleError(err);
@@ -90,24 +80,6 @@ export class ExportService {
   }
 
   /**
-   * First check if the subjectSet in the 1st step is up to date with a current selection criteria
-   * then create the export
-   * @param {ExportJob} newJob
-   */
-  runExportJobWithSubjectSetConstraint(newJob: ExportJob): Promise<any> {
-      let updatedSelectionConstraint = this.constraintService.subjectSetConstraintIfDifferentInCurrentSelection();
-      if (updatedSelectionConstraint) {
-        this.resourceService.saveSubjectSet('temp', updatedSelectionConstraint).subscribe(newSubjectSet => {
-          this.constraintService.updateSubjectSetConstraint(newSubjectSet.id, updatedSelectionConstraint);
-          return this.runExportJob(newJob)
-        });
-      }
-      else {
-        return this.runExportJob(newJob);
-      }
-  }
-
-  /**
    * Run the just created export job
    * @param job
    */
@@ -115,7 +87,7 @@ export class ExportService {
     return new Promise((resolve, reject) => {
       let constraint = this.constraintService.constraint_1_2();
       this.resourceService.runExportJob(job, this.exportDataTypes, constraint, this.dataTableService.dataTable)
-        .subscribe(
+        .then(
           returnedExportJob => {
             if (returnedExportJob) {
               this.updateExportJobs()

--- a/src/app/services/resource.service.ts
+++ b/src/app/services/resource.service.ts
@@ -313,7 +313,7 @@ export class ResourceService {
   runExportJob(job: ExportJob,
                dataTypes: ExportDataType[],
                constraint: Constraint,
-               dataTable: DataTable): Observable<ExportJob> {
+               dataTable: DataTable): Promise<ExportJob> {
     let includeDataTable = false;
     let hasSelectedFormat = false;
     for (let dataType of dataTypes) {
@@ -336,14 +336,14 @@ export class ResourceService {
             transmartTableState = TransmartDataTableMapper.mapDataTableToTableState(dataTable);
           }
           const elements = TransmartMapper.mapExportDataTypes(dataTypes, this.transmartResourceService.exportDataView);
-          return this.transmartResourceService.runExportJob(job.id, constraint, elements, transmartTableState);
+          return this.transmartResourceService.runExport(job.id, constraint, elements, transmartTableState);
         }
         default: {
-          return this.handleEndpointModeError();
+          return this.handleEndpointModeError().toPromise();
         }
       }
     } else {
-      return Observable.of(null);
+      return Observable.of(null).toPromise();
     }
   }
 


### PR DESCRIPTION
Description of the issue: [TMT-265](https://jira.thehyve.nl/browse/TMT-265)
When autosave-subject-sets option was set to true, exported data was not up to date with a selection from step1.

The export behavior for autosave-subject-sets mode is changed to first check if step 1 subject set is up to date with criteria. If it is not, a new subject set is created and then based on it the export is created.