### PR TITLE
Prevent redirect when dropping an item in the cross table drop zone.

### DIFF
--- a/src/app/modules/gb-analysis-module/gb-droppable-zone/gb-droppable-zone.component.html
+++ b/src/app/modules/gb-analysis-module/gb-droppable-zone/gb-droppable-zone.component.html
@@ -3,7 +3,7 @@
      [ngClass]="{'gb-droppable-zone-container-highlight': dragCounter > 0}"
      (onDragEnter)="onDragEnter($event)"
      (onDragLeave)="onDragLeave($event)"
-     (drop)="onDrop()">
+     (drop)="onDrop($event)">
 
   <div class="row">
     <div *ngFor="let constraint of constraints"

--- a/src/app/modules/gb-analysis-module/gb-droppable-zone/gb-droppable-zone.component.spec.ts
+++ b/src/app/modules/gb-analysis-module/gb-droppable-zone/gb-droppable-zone.component.spec.ts
@@ -98,9 +98,10 @@ describe('GbDroppableZoneComponent', () => {
   })
 
   it('should conditionally update cross table when a constraint cell is dropped', () => {
+    let mockEvent = new DragEvent('drop');
     crossTableService.selectedConstraintCell = null;
     treeNodeService.selectedTreeNode = null;
-    component.onDrop();
+    component.onDrop(mockEvent);
     expect(component.dragCounter).toEqual(0);
     expect(crossTableService.selectedConstraintCell).toBe(null);
 
@@ -108,14 +109,14 @@ describe('GbDroppableZoneComponent', () => {
     let dummy = new TrueConstraint();
     let spy1 = spyOn(constraintService, 'generateConstraintFromTreeNode').and.returnValue(dummy);
     let spy2 = spyOn(MessageHelper, 'alert').and.stub();
-    component.onDrop();
+    component.onDrop(mockEvent);
     expect(spy1).toHaveBeenCalled();
     expect(spy2).toHaveBeenCalledTimes(1);
 
     let spy3 = spyOn(crossTableService, 'isValidConstraint').and.returnValue(true);
     let dummyText = 'dummy text';
     let spy4 = spyOn(CrossTableService, 'brief').and.returnValue(dummyText);
-    component.onDrop();
+    component.onDrop(mockEvent);
     expect(spy3).toHaveBeenCalled();
     expect(spy4).toHaveBeenCalled();
     expect(dummy.textRepresentation).toBe(dummyText);
@@ -129,11 +130,11 @@ describe('GbDroppableZoneComponent', () => {
     let spy6 = spyOnProperty(crossTableService, 'selectedConstraintCell', 'get')
       .and.returnValue(dummySelectedCell);
     let spy7 = spyOn(dummySelectedCell, 'remove').and.stub();
-    component.onDrop();
+    component.onDrop(mockEvent);
     expect(spy6).toHaveBeenCalled();
 
     component.constraints = [];
-    component.onDrop();
+    component.onDrop(mockEvent);
     expect(component.constraints.length).toEqual(1);
     expect(component.constraints).toContain(dummy);
     expect(spy7).toHaveBeenCalled();

--- a/src/app/modules/gb-analysis-module/gb-droppable-zone/gb-droppable-zone.component.ts
+++ b/src/app/modules/gb-analysis-module/gb-droppable-zone/gb-droppable-zone.component.ts
@@ -53,7 +53,8 @@ export class GbDroppableZoneComponent implements OnInit {
     this.dragCounter--;
   }
 
-  onDrop() {
+  onDrop(e) {
+    e.preventDefault();
     const selectedConstraintCell = this.crossTableService.selectedConstraintCell;
     let constraint = selectedConstraintCell ? selectedConstraintCell.constraint : null;
     // if no existing constraint (from one of the already created draggable cells) is used,

--- a/src/app/modules/gb-data-selection-module/data-table-components/gb-data-table-dimensions/gb-data-table-dimensions.component.html
+++ b/src/app/modules/gb-data-selection-module/data-table-components/gb-data-table-dimensions/gb-data-table-dimensions.component.html
@@ -13,7 +13,7 @@
               (onMoveAllToSource)="onChange()"
               (onSourceReorder)="onChange()"
               (onTargetReorder)="onChange()"
-              (drop)="onDrop()"
+              (drop)="onDrop($event)"
               [sourceStyle]="{'min-height':'130px','height': '100%'}"
               [targetStyle]="{'min-height':'130px','height': '100%'}">
     <ng-template let-dimension pTemplate="item">

--- a/src/app/modules/gb-data-selection-module/data-table-components/gb-data-table-dimensions/gb-data-table-dimensions.component.ts
+++ b/src/app/modules/gb-data-selection-module/data-table-components/gb-data-table-dimensions/gb-data-table-dimensions.component.ts
@@ -37,7 +37,8 @@ export class GbDataTableDimensionsComponent implements OnInit {
    * This function handles the drop event when the user is reordering dimensions within
    * the same row-dimension container or the same column-dimension container
    */
-  onDrop() {
+  onDrop(e) {
+    e.preventDefault();
     let changed = false;
     if (this.dataTableService.prevRowDimensions.length === this.dataTableService.rowDimensions.length) {
       for (let i = 0; i < this.dataTableService.rowDimensions.length; i++) {


### PR DESCRIPTION
Fixes [TMT-361](https://jira.thehyve.nl/browse/TMT-361).
The issue only appeared in Firefox, not in Chrome.