### PR TITLE
Reduce the number of alerts at authentication.

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -164,19 +164,31 @@ describe('AppComponent', () => {
     expect(component.messages).toBe(dummy);
   });
 
-  it('should handle authentication', () => {
+  it('should handle authentication success', () => {
     let authenticated = true;
-    let spy1 = spyOnProperty(authenticationService, 'authorised', 'get')
+    let authorisedCall = spyOnProperty(authenticationService, 'authorised', 'get')
       .and.callFake(() => {
         return Observable.of(authenticated);
       });
-    let spy2 = spyOn(MessageHelper, 'alert').and.stub();
+    let messageHelperCall = spyOn(MessageHelper, 'alert').and.stub();
     component.ngOnInit();
-    expect(spy1).toHaveBeenCalled();
-    expect(spy2).toHaveBeenCalledWith('success', 'Authentication successful!');
+    expect(authorisedCall).toHaveBeenCalledTimes(1);
+    expect(messageHelperCall).toHaveBeenCalledTimes(1);
+    expect(messageHelperCall).toHaveBeenCalledWith('success', 'Authentication successful!');
+    expect(component.authenticationCompleted).toEqual(true);
+  });
 
-    authenticated = false;
+  it('should handle authentication failure', () => {
+    let authenticated = false;
+    let authorisedCall = spyOnProperty(authenticationService, 'authorised', 'get')
+      .and.callFake(() => {
+        return Observable.of(authenticated);
+      });
+    let messageHelperCall = spyOn(MessageHelper, 'alert').and.stub();
     component.ngOnInit();
-    expect(spy2).toHaveBeenCalledWith('error', 'Authentication failed!');
-  })
+    expect(authorisedCall).toHaveBeenCalledTimes(1);
+    expect(messageHelperCall).toHaveBeenCalledTimes(0);
+    expect(component.authenticationCompleted).toEqual(false);
+  });
+
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,6 @@ export class AppComponent implements OnInit {
         this._authenticationCompleted = true;
       } else {
         console.warn('Authenticated failed.');
-        MessageHelper.alert('error', 'Authentication failed!');
       }
     });
   }

--- a/src/app/services/authentication/oauth2-authentication.ts
+++ b/src/app/services/authentication/oauth2-authentication.ts
@@ -109,7 +109,6 @@ export class Oauth2Authentication implements AuthenticationMethod {
             this._lock = false;
           });
         }, (error: any) => {
-          ErrorHelper.handleError(error);
           console.error(`Error retrieving token using ${grantType}: ${error}`);
           if (grantType === 'refresh_token') {
             // Remove previous token
@@ -243,11 +242,7 @@ export class Oauth2Authentication implements AuthenticationMethod {
       target = `${this.apiUrl}/logout`;
     }
     MessageHelper.alert('info', 'Redirect to logout page ...');
-    console.log(`Redirecting to ${target} ...`);
-    setTimeout(() => {
-        window.location.assign(target);
-      }, 4000
-    );
+    RedirectHelper.redirectTo(target);
   }
 
 }


### PR DESCRIPTION
This removes the two error notifications when opening Glowing Bear, when redirecting to Keycloak:
- `A server-side error occurred`
- `Authentication failed!`