### PR TITLE
Revert previous update flow for export

### DIFF
--- a/src/app/services/navbar.service.ts
+++ b/src/app/services/navbar.service.ts
@@ -61,8 +61,6 @@ export class NavbarService {
               .then(() => {
                 this.queryService.update_3()
                   .then(() => {
-                    // update the export variables
-                    this.exportService.updateExports();
                     resolve(true);
                   })
                   .catch(err => {

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -236,6 +236,7 @@ export class QueryService {
   public update_1(initialUpdate?: boolean): Promise<any> {
     return new Promise((resolve, reject) => {
       // update export flags
+      this.exportService.isLoadingExportDataTypes = true;
       this.isUpdating_1 = true;
       // set the flags
       this.loadingStateInclusion = 'loading';
@@ -338,6 +339,8 @@ export class QueryService {
               this.isUpdating_2 = false;
               this.isDirty_2 = false;
               this.isDirty_3 = true;
+              // update the export variables
+              this.exportService.updateExports();
               // update the final tree nodes in the summary panel
               if (this.counts_2.subjectCount > 0) {
                 this.treeNodeService.updateFinalTreeNodes();


### PR DESCRIPTION
There was a change introduced in [this commit](https://github.com/thehyve/glowing-bear/commit/006c3dc61d5135f5a4667e9220aa366dc220f57e) to get rid of the error message about no export access, when clicking Step 2 update (it should not be showed there). But apparently it introduced to many different issues, so better to revert it for now and fix the error messages later. 

Fixes [TMT-386](https://jira.thehyve.nl/browse/TMT-386)