### PR TITLE
Info instead of warning when redirecting to login.

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -9,8 +9,8 @@
   padding: 8px 12px;
 }
 
-.gb-warning {
+.gb-info {
   color: black;
-  background-color: #ffffcc;
-  border-left: 6px solid #ffeb3b;
+  background-color: #f0f0f0;
+  border-left: 6px solid #13b4e6;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,7 +3,7 @@
 <gb-main *ngIf="authenticationCompleted"></gb-main>
 
 <div class="gb-page" *ngIf="!authenticationCompleted">
-  <div class="gb-message-box gb-warning">
-  Not authenticated. You are being redirected to the login page ...
+  <div class="gb-message-box gb-info">
+  You are being redirected to the login page to authenticate ...
   </div>
 </div>


### PR DESCRIPTION
Based on first time user feedback: the warning message shown on the redirect page can be a little bit distressing, while it is actually expected behaviour. This change makes the message a bit friendlier by changing the wording and colours used.