### PR TITLE
Hide observation counts in the tree if specified in configuration.

### DIFF
--- a/src/app/config/app.config.ts
+++ b/src/app/config/app.config.ts
@@ -47,7 +47,7 @@ export class AppConfig {
    */
   public getConfig(key: any) {
     let value = this.config[key];
-    if (value == null) {
+    if (value === null || value === undefined) {
       switch (key) {
         case 'api-url': {
           throw Error('The API URL is unspecified in the configuration.')

--- a/src/app/config/app.config.ts
+++ b/src/app/config/app.config.ts
@@ -47,7 +47,7 @@ export class AppConfig {
    */
   public getConfig(key: any) {
     let value = this.config[key];
-    if (!value) {
+    if (value == null) {
       switch (key) {
         case 'api-url': {
           throw Error('The API URL is unspecified in the configuration.')

--- a/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
+++ b/src/app/modules/gb-data-selection-module/gb-data-selection.component.html
@@ -95,10 +95,10 @@
           </div>
           <div class="gb-data-selection-accordion-sub-header-2">
             <span class="gb-data-selection-accordion-sub-header-3 float-left">
-              <span class="gb-data-selection-emphasis-text">{{subjectCount_2}} subjects</span>,
-              <span *ngIf="queryService.showObservationCounts"
-                    class="gb-data-selection-emphasis-text">
-                {{observationCount_2}} observations
+              <span class="gb-data-selection-emphasis-text">{{subjectCount_2}} subjects</span>
+              <span *ngIf="queryService.showObservationCounts">
+                ,
+                <span class="gb-data-selection-emphasis-text">{{observationCount_2}} observations</span>
               </span>
             </span>
             <span *ngIf="!queryService.instantCountsUpdate_3" class="float-right">

--- a/src/app/services/tree-node.service.spec.ts
+++ b/src/app/services/tree-node.service.spec.ts
@@ -24,6 +24,8 @@ import {ConceptType} from '../models/constraint-models/concept-type';
 import {MessageHelper} from '../utilities/message-helper';
 import {CountItem} from '../models/aggregate-models/count-item';
 import {throwError} from 'rxjs/internal/observable/throwError';
+import {AppConfigMock} from '../config/app.config.mock';
+import {AppConfig} from '../config/app.config';
 
 describe('TreeNodeService', () => {
   let treeNodeService: TreeNodeService;
@@ -35,6 +37,10 @@ describe('TreeNodeService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
+        {
+          provide: AppConfig,
+          useClass: AppConfigMock
+        },
         {
           provide: ResourceService,
           useClass: ResourceServiceMock

--- a/src/app/services/tree-node.service.ts
+++ b/src/app/services/tree-node.service.ts
@@ -18,6 +18,7 @@ import {MessageHelper} from '../utilities/message-helper';
 import {CountItem} from '../models/aggregate-models/count-item';
 import {TrueConstraint} from '../models/constraint-models/true-constraint';
 import {HttpErrorResponse} from '@angular/common/http';
+import {AppConfig} from '../config/app.config';
 
 @Injectable()
 export class TreeNodeService {
@@ -98,8 +99,11 @@ export class TreeNodeService {
   // the status indicating the when the tree is being loaded or finished loading
   private _validTreeNodeTypes: string[] = [];
 
+  // Flag indicating if the observation counts are calculated and shown
+  private _showObservationCounts: boolean;
 
-  constructor(private resourceService: ResourceService, private injector: Injector) {
+  constructor(private appConfig: AppConfig, private resourceService: ResourceService, private injector: Injector) {
+    this.showObservationCounts = this.appConfig.getConfig('show-observation-counts');
     this.validTreeNodeTypes = [
       'NUMERIC',
       'CATEGORICAL',
@@ -524,7 +528,11 @@ export class TreeNodeService {
           countItem = this.selectedConceptCountMap.get(node['conceptCode']);
         }
         if (countItem) {
-          node['label'] = node['name'] + ` (sub: ${countItem.subjectCount}, obs: ${countItem.observationCount})`;
+          let countsText = `sub: ${countItem.subjectCount}`;
+          if (this.showObservationCounts) {
+            countsText += `, obs: ${countItem.observationCount}`;
+          }
+          node['label'] = `${node['name']} (${countsText})`;
           nodesWithCodes.push(node);
         }
       } else if (node['children']) { // if the node is an intermediate node
@@ -902,4 +910,13 @@ export class TreeNodeService {
   set selectedConceptCountMap(value: Map<string, CountItem>) {
     this._selectedConceptCountMap = value;
   }
+
+  get showObservationCounts(): boolean {
+    return this._showObservationCounts;
+  }
+
+  set showObservationCounts(value: boolean) {
+    this._showObservationCounts = value;
+  }
+
 }

--- a/src/tests/cross-table.integration.spec.ts
+++ b/src/tests/cross-table.integration.spec.ts
@@ -23,6 +23,8 @@ import {Concept} from '../app/models/constraint-models/concept';
 import {ConceptType} from '../app/models/constraint-models/concept-type';
 import {StudyService} from '../app/services/study.service';
 import {ValueConstraint} from '../app/models/constraint-models/value-constraint';
+import {AppConfigMock} from '../app/config/app.config.mock';
+import {AppConfig} from '../app/config/app.config';
 
 describe('Integration tests for cross table ', () => {
 
@@ -34,6 +36,10 @@ describe('Integration tests for cross table ', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
+        {
+          provide: AppConfig,
+          useClass: AppConfigMock
+        },
         {
           provide: ResourceService,
           useClass: ResourceServiceMock

--- a/src/tests/export.integration.spec.ts
+++ b/src/tests/export.integration.spec.ts
@@ -13,6 +13,8 @@ import {ExportJob} from '../app/models/export-models/export-job';
 import {StudyService} from '../app/services/study.service';
 import {AuthenticationService} from '../app/services/authentication/authentication.service';
 import {AuthenticationServiceMock} from '../app/services/mocks/authentication.service.mock';
+import {AppConfigMock} from '../app/config/app.config.mock';
+import {AppConfig} from '../app/config/app.config';
 
 describe('Integration test for data export', () => {
 
@@ -22,6 +24,10 @@ describe('Integration test for data export', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
+        {
+          provide: AppConfig,
+          useClass: AppConfigMock
+        },
         {
           provide: ResourceService,
           useClass: ResourceServiceMock


### PR DESCRIPTION
Not sure where to put the defaults for config values. Now I moved the property `showObservationCounts` from the query service to the tree node service, but ideally there is a separate injectable object that contains such properties and has the default values.