### PR TITLE
Use constraint from the cohort selection when saving a cohort

### DIFF
--- a/src/app/services/cohort.service.ts
+++ b/src/app/services/cohort.service.ts
@@ -92,7 +92,7 @@ export class CohortService {
     return new Promise((resolve, reject) => {
       if (this.isDirty) {
         this.isUpdatingCurrent = true;
-        let constraint = this.constraintService.cohortSelectionConstraint();
+        let constraint = this.constraintService.cohortSelectionConstraint;
         this.countService.updateCurrentSelectionCount(constraint)
           .then(() => {
             this.currentCohort.constraint = constraint;
@@ -212,9 +212,10 @@ export class CohortService {
 
   public saveCohortByName(name: string) {
     let result = new Cohort('', name);
-    result.constraint = this.currentCohort.constraint;
-    if (this.currentCohort.constraint.className === 'CombinationConstraint') {
-      result.type = (<CombinationConstraint>this.currentCohort.constraint).dimension;
+    let constraint = this.constraintService.cohortSelectionConstraint;
+    result.constraint = constraint;
+    if (constraint.className === 'CombinationConstraint') {
+      result.type = (<CombinationConstraint>constraint).dimension;
     }
     this.saveCohort(result);
   }

--- a/src/app/services/constraint.service.ts
+++ b/src/app/services/constraint.service.ts
@@ -174,7 +174,7 @@ export class ConstraintService {
    * Get the constraint based on the current cohort selection criteria
    * @returns {Constraint}
    */
-  public cohortSelectionConstraint(): Constraint {
+  get cohortSelectionConstraint(): Constraint {
     let constraint = <Constraint>this.rootConstraint;
     if (!ConstraintHelper.hasNonEmptyChildren(<CombinationConstraint>constraint)) {
       constraint = new TrueConstraint();

--- a/src/app/services/variable.service.ts
+++ b/src/app/services/variable.service.ts
@@ -281,7 +281,7 @@ export class VariableService {
   // get the combination of cohort constraint and variable constraint
   get combination(): Constraint {
     return new CombinationConstraint(
-      [this.constraintService.cohortSelectionConstraint(),
+      [this.constraintService.cohortSelectionConstraint,
         this.constraintService.variableConstraint(this.variables)],
       CombinationState.And
     );


### PR DESCRIPTION
Previously the current cohort constraint was used, which is not updated
until the counts are finished, so othe constraint saved for a cohort was not always in sync with what was in the cohort selection.