### PR TITLE
Set root dimension type explicitly, when restoring constraint other than combination

### DIFF
--- a/src/app/services/constraint.service.spec.ts
+++ b/src/app/services/constraint.service.spec.ts
@@ -93,4 +93,19 @@ describe('ConstraintService', () => {
       .toBe(1);
   });
 
+
+  it('should restore cohort constraint with proper root dimenstion', () => {
+    let constraint1 = new CombinationConstraint();
+    constraint1.dimension = 'diagnosis';
+    let constraint11 = new ConceptConstraint();
+    constraint1.addChild(constraint11);
+
+    let constraint2 = new ConceptConstraint();
+
+    constraintService.restoreCohortConstraint(constraint1);
+    expect(constraintService.rootConstraint.dimension).toEqual('diagnosis');
+
+    constraintService.restoreCohortConstraint(constraint2);
+    expect(constraintService.rootConstraint.dimension).toEqual('patient');
+  });
 });

--- a/src/app/services/constraint.service.ts
+++ b/src/app/services/constraint.service.ts
@@ -222,6 +222,7 @@ export class ConstraintService {
       }
       this.rootConstraint.combinationState = (<CombinationConstraint>constraint).combinationState;
     } else if (constraint.className !== 'TrueConstraint') {
+      this.rootConstraint.dimension = CombinationConstraint.TOP_LEVEL_DIMENSION;
       this.rootConstraint.addChild(constraint);
     }
   }


### PR DESCRIPTION
Fixes: [TMT-882](https://jira.thehyve.nl/browse/TMT-882) - when restoring a cohort of type patient, root dimension is not overwritten 