### PR TITLE
 Fix parent nodes selection when importing variables for export 

### DIFF
--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-variables/gb-variables.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-variables/gb-variables.component.html
@@ -17,10 +17,10 @@
               (click)="importVariables()"
               type="button">
         <span>import</span>
-        <input [id]="fileElementId"
-               type="file"
-               style="display: none"/>
       </button>
+      <input [id]="variableFileElementId"
+             type="file"
+             style="display: none"/>
     </div>
   </div>
 

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-variables/gb-variables.component.spec.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-variables/gb-variables.component.spec.ts
@@ -148,23 +148,27 @@ describe('GbVariablesComponent', () => {
   it('should handle importing variables by names', () => {
     const result = '{"names": ["test-name-1", "test-name-3"]}';
     const e = new Event('');
+    const spyMessage = spyOn(MessageHelper, 'alert').and.stub();
     spyOnProperty(e, 'target', 'get').and.returnValue({result: result});
     const file = new File([], 'test.json', {type: 'application/json'});
     spyOn(FileImportHelper, 'getFile').and.returnValue(file);
     const spyCall = spyOn(variableService, 'importVariablesByNames').and.stub();
     component.handleVariablesFileUploadEvent(e);
     expect(spyCall).toHaveBeenCalled();
+    expect(spyMessage).toHaveBeenCalledWith('info', 'Variables file upload successful!');
   });
 
   it('should handle importing variables by paths', () => {
     const result = '{"paths": ["foobar"]}';
     const e = new Event('');
+    const spyMessage = spyOn(MessageHelper, 'alert').and.stub();
     spyOnProperty(e, 'target', 'get').and.returnValue({result: result});
     const file = new File([], 'test.json', {type: 'application/json'});
     spyOn(FileImportHelper, 'getFile').and.returnValue(file);
     const spyCall = spyOn(variableService, 'importVariablesByPaths').and.stub();
     component.handleVariablesFileUploadEvent(e);
     expect(spyCall).toHaveBeenCalled();
+    expect(spyMessage).toHaveBeenCalledWith('info', 'Variables file upload successful!');
   });
 
   it('should enable check mark only when all variables are selected', () => {

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-variables/gb-variables.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-variables/gb-variables.component.ts
@@ -26,7 +26,7 @@ export class GbVariablesComponent implements OnInit {
   public availableViewModes: SelectItem[];
 
   public VariablesViewMode = VariablesViewMode; // make enum visible in template
-  public readonly fileElementId: string = 'variablesCriteriaFileUpload';
+  public readonly variableFileElementId: string = 'variablesCriteriaFileUpload';
 
   public isUploadListenerNotAdded: boolean;
   public file: File; // holds the uploaded cohort file
@@ -53,13 +53,13 @@ export class GbVariablesComponent implements OnInit {
   importVariables() {
     let reader = new FileReader();
     reader.onload = this.handleVariablesFileUploadEvent.bind(this);
-    FileImportHelper.importCriteria(this.fileElementId, reader, this.isUploadListenerNotAdded);
+    FileImportHelper.importCriteria(this.variableFileElementId, reader, this.isUploadListenerNotAdded);
     this.isUploadListenerNotAdded = false;
   }
 
   handleVariablesFileUploadEvent(e) {
     let data = e.target['result'];
-    this.file = FileImportHelper.getFile(this.fileElementId);
+    this.file = FileImportHelper.getFile(this.variableFileElementId);
     // file.type is empty for some browsers and Windows OS
     if (FileImportHelper.isJsonFile(this.file)) {
       let _json = JSON.parse(data);

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-variables/gb-variables.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-variables/gb-variables.component.ts
@@ -71,6 +71,7 @@ export class GbVariablesComponent implements OnInit {
         MessageHelper.alert('error', 'Invalid file content for variables import.');
         return;
       }
+      MessageHelper.alert('info', 'Variables file upload successful!');
     } else {
       MessageHelper.alert('error', 'Invalid file format for variables import.');
       return;

--- a/src/app/services/variable.service.spec.ts
+++ b/src/app/services/variable.service.spec.ts
@@ -240,6 +240,9 @@ describe('VariableService', () => {
     expect(variableService.selectedVariablesTree.length).toBe(2);
     expect(variableService.selectedVariablesTree).toContain(node_1_2);
     expect(variableService.selectedVariablesTree).toContain(node_2);
+    expect(node_1_1.partialSelected).toBe(undefined);
+    expect(node_1.partialSelected).toBe(true);
+    expect(node.partialSelected).toBe(true);
 
     spyOn(treeNodeService, 'isVariableNode').and.returnValue(true);
 
@@ -249,6 +252,9 @@ describe('VariableService', () => {
     expect(variableService.selectedVariablesTree.length).toBe(2);
     expect(variableService.selectedVariablesTree).toContain(node_1_2);
     expect(variableService.selectedVariablesTree).toContain(node_2);
+    expect(node_1_1.partialSelected).toBe(undefined);
+    expect(node_1.partialSelected).toBe(true);
+    expect(node.partialSelected).toBe(true);
   });
 
   it('should remove unselected tree nodes when additional import is off', () => {
@@ -274,7 +280,7 @@ describe('VariableService', () => {
       [node], ['\\foo\\bar\\node_1_2\\', '\\dummy\\'], ['fullName'], false);
     expect(variableService.selectedVariablesTree.length).toBe(1);
     expect(variableService.selectedVariablesTree).toContain(node_1_2);
-  })
+  });
 
   it('should select variables tree nodes by names', () => {
     let nodeABC: TreeNode = {};
@@ -293,8 +299,14 @@ describe('VariableService', () => {
     nodeA.children = [nodeAB, nodeAD];
     variableService.selectVariablesTreeByFields([nodeA], ['name1'], ['metadata', 'item_name'], true);
 
-    expect(variableService.selectedVariablesTree.length).toBe(1);
+    expect(variableService.selectedVariablesTree.length).toBe(2);
     expect(variableService.selectedVariablesTree).toContain(nodeADE);
+    // parent nodes:
+    expect(variableService.selectedVariablesTree).toContain(nodeAD);
+    expect(nodeA.partialSelected).toBe(true);
+
+    expect(nodeAB.partialSelected).toBe(undefined);
+    expect(nodeABC.partialSelected).toBe(undefined);
   });
 
   it('should update variables tree data', () => {

--- a/src/app/services/variable.service.spec.ts
+++ b/src/app/services/variable.service.spec.ts
@@ -194,6 +194,8 @@ describe('VariableService', () => {
     expect(variableService.selectedVariablesTree).not.toContain(node_1_2);
     expect(variableService.selectedVariablesTree).toContain(node_2);
     expect(variableService.selectedVariablesTree).toContain(node_1_1);
+    expect(node.partialSelected).toBe(true);
+    expect(node_1.partialSelected).toBe(true);
   });
 
   it('should unselect all variables that are shared between nodes', () => {
@@ -214,6 +216,7 @@ describe('VariableService', () => {
 
     variableService.selectedVariablesTree = [node];
     variableService.unselectVariablesTreeByFields([node], [node_1_1['conceptCode']], ['conceptCode']);
+    expect(variableService.selectedVariablesTree.length).toBe(1);
     expect(variableService.selectedVariablesTree).not.toContain(node_2);
     expect(variableService.selectedVariablesTree).not.toContain(node_1_1);
   });

--- a/src/app/services/variable.service.ts
+++ b/src/app/services/variable.service.ts
@@ -17,6 +17,8 @@ import {CountItem} from '../models/aggregate-models/count-item';
 import {CountService} from './count.service';
 import {GbTreeNode} from '../models/tree-node-models/gb-tree-node';
 import {UIHelper} from '../utilities/ui-helper';
+import {TreeNode} from 'primeng/api';
+import {TreeNodeHelper} from '../utilities/tree-node-helper';
 
 @Injectable({
   providedIn: 'root'
@@ -251,23 +253,19 @@ export class VariableService {
       if (node) {
         const val = fields.length < 2 ? node[fields[0]] : (node[fields[0]] || {})[fields[1]];
         if (values.includes(val) && !this.selectedVariablesTree.includes(node)) {
-          this.selectedVariablesTree.push(node);
-          UIHelper.selectPrimeNgTreeParentNodesRecursively(node.parent, this.selectedVariablesTree);
+          TreeNodeHelper.addNodeToSelectedNodes(node, this.selectedVariablesTree);
+          TreeNodeHelper.updateParentNodesSelectionRecursively(node.parent, this.selectedVariablesTree);
         } else if (
           !isSelectionIncremental
           && !values.includes(val)
           && this.treeNodeService.isVariableNode(node)
           && this.selectedVariablesTree.includes(node)
         ) {
-          const index = this.selectedVariablesTree.indexOf(node);
-          this.selectedVariablesTree.splice(index, 1);
+          TreeNodeHelper.removeNodeFromSelectedNodes(node, this.selectedVariablesTree);
+          TreeNodeHelper.updateParentNodesSelectionRecursively(node.parent, this.selectedVariablesTree);
         }
         if (node['children']) {
-          node.children.forEach((child) => {
-            if (child) {
-              child.parent = node
-            }
-          });
+          TreeNodeHelper.updateParentForAllChildren(node);
           this.selectVariablesTreeByFields(node['children'], values, fields, isSelectionIncremental);
         }
       }
@@ -279,10 +277,11 @@ export class VariableService {
       if (node) {
         const val = fields.length < 2 ? node[fields[0]] : (node[fields[0]] || {})[fields[1]];
         if (values.includes(val) && this.selectedVariablesTree.includes(node)) {
-          const index = this.selectedVariablesTree.indexOf(node);
-          this.selectedVariablesTree.splice(index, 1);
+          TreeNodeHelper.removeNodeFromSelectedNodes(node, this.selectedVariablesTree);
+          TreeNodeHelper.updateParentNodesSelectionRecursively(node.parent, this.selectedVariablesTree);
         }
         if (node['children']) {
+          TreeNodeHelper.updateParentForAllChildren(node);
           this.unselectVariablesTreeByFields(node['children'], values, fields);
         }
       }

--- a/src/app/services/variable.service.ts
+++ b/src/app/services/variable.service.ts
@@ -16,6 +16,7 @@ import {CombinationState} from '../models/constraint-models/combination-state';
 import {CountItem} from '../models/aggregate-models/count-item';
 import {CountService} from './count.service';
 import {GbTreeNode} from '../models/tree-node-models/gb-tree-node';
+import {UIHelper} from '../utilities/ui-helper';
 
 @Injectable({
   providedIn: 'root'
@@ -249,10 +250,9 @@ export class VariableService {
     nodes.forEach((node: GbTreeNode) => {
       if (node) {
         const val = fields.length < 2 ? node[fields[0]] : (node[fields[0]] || {})[fields[1]];
-        if (
-          values.includes(val)
-          && !this.selectedVariablesTree.includes(node)) {
+        if (values.includes(val) && !this.selectedVariablesTree.includes(node)) {
           this.selectedVariablesTree.push(node);
+          UIHelper.selectPrimeNgParentTreeNode(node, this.selectedVariablesTree);
         } else if (
           !isSelectionIncremental
           && !values.includes(val)
@@ -263,6 +263,7 @@ export class VariableService {
           this.selectedVariablesTree.splice(index, 1);
         }
         if (node['children']) {
+          node.children.forEach((child) => child.parent = node);
           this.selectVariablesTreeByFields(node['children'], values, fields, isSelectionIncremental);
         }
       }

--- a/src/app/services/variable.service.ts
+++ b/src/app/services/variable.service.ts
@@ -252,7 +252,7 @@ export class VariableService {
         const val = fields.length < 2 ? node[fields[0]] : (node[fields[0]] || {})[fields[1]];
         if (values.includes(val) && !this.selectedVariablesTree.includes(node)) {
           this.selectedVariablesTree.push(node);
-          UIHelper.selectPrimeNgParentTreeNode(node, this.selectedVariablesTree);
+          UIHelper.selectPrimeNgTreeParentNodesRecursively(node.parent, this.selectedVariablesTree);
         } else if (
           !isSelectionIncremental
           && !values.includes(val)

--- a/src/app/services/variable.service.ts
+++ b/src/app/services/variable.service.ts
@@ -263,7 +263,11 @@ export class VariableService {
           this.selectedVariablesTree.splice(index, 1);
         }
         if (node['children']) {
-          node.children.forEach((child) => child.parent = node);
+          node.children.forEach((child) => {
+            if (child) {
+              child.parent = node
+            }
+          });
           this.selectVariablesTreeByFields(node['children'], values, fields, isSelectionIncremental);
         }
       }

--- a/src/app/utilities/tree-node-helper.ts
+++ b/src/app/utilities/tree-node-helper.ts
@@ -29,7 +29,10 @@ export class TreeNodeHelper {
       this.addNodeToSelectedNodes(parent, selectedNodes);
     } else {
       this.removeNodeFromSelectedNodes(parent, selectedNodes);
-      this.updateNodePartialSelection(parent, selectedNodes);
+      if (parent.children.some((child: GbTreeNode) =>
+        (selectedNodes.includes(child) || child.partialSelected === true))) {
+        parent.partialSelected = true;
+      }
     }
     this.updateParentNodesSelectionRecursively(parent.parent, selectedNodes);
   }
@@ -69,21 +72,6 @@ export class TreeNodeHelper {
    */
   public static  addNodeToSelectedNodes(node: GbTreeNode, selectedNodes: GbTreeNode[]) {
     selectedNodes.push(node);
-  }
-
-  /**
-   * Function to partially select a tree node with the '-' icon.
-   *
-   * Partial selection means that only part of the children nodes is selected.
-   *
-   * @param node to be partially select
-   * @param selectedNodes current tree nodes selection
-   */
-  private static updateNodePartialSelection(node: GbTreeNode, selectedNodes: GbTreeNode[]) {
-    if (node.children.some((child: GbTreeNode) =>
-      (selectedNodes.includes(child) || child.partialSelected === true))) {
-      node.partialSelected = true;
-    }
   }
 
 }

--- a/src/app/utilities/tree-node-helper.ts
+++ b/src/app/utilities/tree-node-helper.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2019 The Hyve B.V.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import {GbTreeNode} from '../models/tree-node-models/gb-tree-node';
+
+export class TreeNodeHelper {
+
+  /**
+   * For a tree node, this function selects its parent nodes recursively.
+   *
+   * It should be used, when selecting a tree node programmatically.
+   * Reason: the PrimeNg library does not handle selecting of a parent node,
+   * when the selection of the node is not triggered by a mouse click event.
+   *
+   * @param parent a parent node of a selected node
+   * @param selectedNodes array of currently selected nodes
+   */
+  public static updateParentNodesSelectionRecursively(parent: GbTreeNode, selectedNodes: GbTreeNode[]) {
+    if (parent === undefined) {
+      return;
+    }
+    parent.partialSelected = false;
+    if (parent.children.every((child: GbTreeNode) => selectedNodes.includes(child))) {
+      this.addNodeToSelectedNodes(parent, selectedNodes);
+    } else {
+      this.removeNodeFromSelectedNodes(parent, selectedNodes);
+      this.updateNodePartialSelection(parent, selectedNodes);
+    }
+    this.updateParentNodesSelectionRecursively(parent.parent, selectedNodes);
+  }
+
+  /**
+   * For a tree node, this function updates all of its children by setting the node as their parent.
+   *
+   * This is required for the tree nodes checkboxes update.
+   * @param node
+   */
+  public static updateParentForAllChildren(node: GbTreeNode) {
+    node.children.forEach((child) => {
+      if (child) {
+        child.parent = node
+      }
+    });
+  }
+
+  /**
+   * Helper function for deselecting a tree node.
+   *
+   * @param node deselected node
+   * @param selectedNodes current tree nodes selection
+   */
+  public static  removeNodeFromSelectedNodes(node: GbTreeNode, selectedNodes: GbTreeNode[]) {
+    const index = selectedNodes.indexOf(node, 0);
+    if (index > -1) {
+      selectedNodes.splice(index, 1);
+    }
+  }
+
+  /**
+   * Helper function for selecting a tree node.
+   *
+   * @param node selected node
+   * @param selectedNodes current tree nodes selection
+   */
+  public static  addNodeToSelectedNodes(node: GbTreeNode, selectedNodes: GbTreeNode[]) {
+    selectedNodes.push(node);
+  }
+
+  /**
+   * Function to partially select a tree node with the '-' icon.
+   *
+   * Partial selection means that only part of the children nodes is selected.
+   *
+   * @param node to be partially select
+   * @param selectedNodes current tree nodes selection
+   */
+  private static updateNodePartialSelection(node: GbTreeNode, selectedNodes: GbTreeNode[]) {
+    if (node.children.some((child: GbTreeNode) =>
+      (selectedNodes.includes(child) || child.partialSelected === true))) {
+      node.partialSelected = true;
+    }
+  }
+
+}

--- a/src/app/utilities/ui-helper.ts
+++ b/src/app/utilities/ui-helper.ts
@@ -7,8 +7,6 @@
  */
 
 import {ElementRef} from '@angular/core';
-import {TreeNode} from 'primeng/api';
-import {GbTreeNode} from '../models/tree-node-models/gb-tree-node';
 
 export class UIHelper {
 
@@ -25,28 +23,6 @@ export class UIHelper {
         loaderIcon.remove();
       }
     }).bind(this), delay);
-  }
-
-  /**
-   * For a tree node, this function selects its parent nodes recursively.
-   *
-   * It should be used, when selecting a tree node programmatically.
-   * Reason: the PrimeNg library does not handle selecting of a parent node,
-   * when the selection of the node is not triggered by a mouse click event.
-   *
-   * @param parent a parent node of a selected node
-   * @param selectedNodes array of currently selected nodes
-   */
-  public static selectPrimeNgTreeParentNodesRecursively(parent: TreeNode, selectedNodes: GbTreeNode[]) {
-    if (parent === undefined) {
-      return;
-    }
-    if (parent.children.every((child: TreeNode) => selectedNodes.includes(child))) {
-      selectedNodes.push(parent);
-    } else {
-      parent.partialSelected = true;
-    }
-    this.selectPrimeNgTreeParentNodesRecursively(parent.parent, selectedNodes);
   }
 
 }

--- a/src/app/utilities/ui-helper.ts
+++ b/src/app/utilities/ui-helper.ts
@@ -28,21 +28,25 @@ export class UIHelper {
   }
 
   /**
-   * The PrimeNg library does not handle selecting of a parent node
-   * when selecting the node programmatically
-   * @param node parent of which has to be (partially) selected
-   * @param selectedNodes array of currently selecte nodes
+   * For a tree node, this function selects its parent nodes recursively.
+   *
+   * It should be used, when selecting a tree node programmatically.
+   * Reason: the PrimeNg library does not handle selecting of a parent node,
+   * when the selection of the node is not triggered by a mouse click event.
+   *
+   * @param parent a parent node of a selected node
+   * @param selectedNodes array of currently selected nodes
    */
-  public static selectPrimeNgParentTreeNode(node: TreeNode, selectedNodes: GbTreeNode[]) {
-    if (node.parent != null) {
-      if (node.parent.children.every((child: TreeNode) => selectedNodes.includes(child))) {
-        selectedNodes.push(node.parent);
-      } else {
-        node.parent.partialSelected = true;
-      }
-      if (node.parent.parent != null) {
-        this.selectPrimeNgParentTreeNode(node.parent, selectedNodes);
-      }
+  public static selectPrimeNgTreeParentNodesRecursively(parent: TreeNode, selectedNodes: GbTreeNode[]) {
+    if (parent === undefined) {
+      return;
     }
+    if (parent.children.every((child: TreeNode) => selectedNodes.includes(child))) {
+      selectedNodes.push(parent);
+    } else {
+      parent.partialSelected = true;
+    }
+    this.selectPrimeNgTreeParentNodesRecursively(parent.parent, selectedNodes);
   }
+
 }

--- a/src/app/utilities/ui-helper.ts
+++ b/src/app/utilities/ui-helper.ts
@@ -24,5 +24,4 @@ export class UIHelper {
       }
     }).bind(this), delay);
   }
-
 }

--- a/src/app/utilities/ui-helper.ts
+++ b/src/app/utilities/ui-helper.ts
@@ -7,6 +7,8 @@
  */
 
 import {ElementRef} from '@angular/core';
+import {TreeNode} from 'primeng/api';
+import {GbTreeNode} from '../models/tree-node-models/gb-tree-node';
 
 export class UIHelper {
 
@@ -23,5 +25,24 @@ export class UIHelper {
         loaderIcon.remove();
       }
     }).bind(this), delay);
+  }
+
+  /**
+   * The PrimeNg library does not handle selecting of a parent node
+   * when selecting the node programmatically
+   * @param node parent of which has to be (partially) selected
+   * @param selectedNodes array of currently selecte nodes
+   */
+  public static selectPrimeNgParentTreeNode(node: TreeNode, selectedNodes: GbTreeNode[]) {
+    if (node.parent != null) {
+      if (node.parent.children.every((child: TreeNode) => selectedNodes.includes(child))) {
+        selectedNodes.push(node.parent);
+      } else {
+        node.parent.partialSelected = true;
+      }
+      if (node.parent.parent != null) {
+        this.selectPrimeNgParentTreeNode(node.parent, selectedNodes);
+      }
+    }
   }
 }


### PR DESCRIPTION
There is an issue in PrimeNG library, when selecting tree nodes programmatically -  parent nodes are not marked as selected or partially selected. A consequence of this in GB is that it is really hard to find which variables were selected in the tree when importing variables in the export tab. 

Relate issue: [TMT-880](https://jira.thehyve.nl/browse/TMT-880)