### PR TITLE
 Disable the dimension selection dropdown after restoring a cohort 

### DIFF
--- a/cypress/integration/cohort-save.feature
+++ b/cypress/integration/cohort-save.feature
@@ -28,7 +28,7 @@ Feature: save cohort
     And I restore the cohort 'Biomaterial ID'
     Then the current cohort has biomaterial selected
     And the cohort 'Biomaterial ID' has type 'Biomaterial ID'
-    And the dimension selection is disabled
+    And the dimension selection is NOT disabled
 
   Scenario: save and restore complex multi-dimension cohort
     Given I am on the cohort-selection tab

--- a/cypress/integration/cohort-save.feature
+++ b/cypress/integration/cohort-save.feature
@@ -28,6 +28,7 @@ Feature: save cohort
     And I restore the cohort 'Biomaterial ID'
     Then the current cohort has biomaterial selected
     And the cohort 'Biomaterial ID' has type 'Biomaterial ID'
+    And the dimension selection is disabled
 
   Scenario: save and restore complex multi-dimension cohort
     Given I am on the cohort-selection tab
@@ -36,3 +37,4 @@ Feature: save cohort
     And I restore the cohort 'Multi dim'
     Then the current cohort has multiple dimensions selected
     And the cohort 'Multi dim' has type 'Biosource ID'
+    And the dimension selection is disabled

--- a/cypress/support/step_definitions/cohort-save.js
+++ b/cypress/support/step_definitions/cohort-save.js
@@ -159,3 +159,7 @@ then('the cohort {string} has type {string}', (cohortName, cohortType) => {
 then('the dimension selection is disabled', () => {
   cy.get('.gb-constraint').find('p-dropdown').children('div').should('have.class', 'ui-state-disabled');
 })
+
+then('the dimension selection is NOT disabled', () => {
+  cy.get('.gb-constraint').find('p-dropdown').children('div').should('not.have.class', 'ui-state-disabled');
+})

--- a/cypress/support/step_definitions/cohort-save.js
+++ b/cypress/support/step_definitions/cohort-save.js
@@ -155,3 +155,7 @@ then('the cohort {string} has type {string}', (cohortName, cohortType) => {
   cy.get('.ng-trigger-tabContent').eq(1).contains(cohortName).parent().parent().parent().parent().click();
   cy.get('.ng-trigger-tabContent').eq(1).contains('Type: ' + cohortType);
 })
+,
+then('the dimension selection is disabled', () => {
+  cy.get('.gb-constraint').find('p-dropdown').children('div').should('have.class', 'ui-state-disabled');
+})

--- a/cypress/support/step_definitions/cross-table.js
+++ b/cypress/support/step_definitions/cross-table.js
@@ -18,7 +18,7 @@ then('A cross table should show up', () => {
 then('Drag CATEGORICAL_VALUES:Demography:Race from tree view to row zone', () => {
   // collapse cohorts panel
   cy.get('.ui-accordion-header').contains('Cohorts').click();
-  cy.get('.loading-container').should('not.be.visible');
+  cy.get('.gb-variables').find('loading-container').should('not.be.visible');
   cy.toggleNode('Public Studies ');
   cy.toggleNode('CATEGORICAL_VALUES ');
   cy.toggleNode('Demography');
@@ -33,7 +33,7 @@ then('Cross table has Latino and Caucasian labels', () => {
 then('Drag Oracle_1000_Patient:Categorical_locations:categorical_12 from tree view to column zone', () => {
   // collapse cohorts panel
   cy.get('.ui-accordion-header').contains('Cohorts').click();
-  cy.get('.loading-container').should('not.be.visible');
+  cy.get('.gb-variables').find('loading-container').should('not.be.visible');
   cy.toggleNode('Public Studies ');
   cy.toggleNode('Oracle_1000_Patient ');
   cy.toggleNode('Categorical_locations');

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.html
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.html
@@ -3,8 +3,8 @@
   <div *ngIf="!hideDimensionDropdown" class="form-inline gb-constraint-dimension-dropdown">
     <label>{{subjectBoxMessage}}</label>
     <p-dropdown [options]="dimensions" [(ngModel)]="selectedDimension"
-                [disabled]="dimensions.length === 1"
-                [dropdownIcon]="dimensions.length === 1 ? '' : 'pi pi-chevron-down'"
+                [disabled]="disableDimensionDropdown"
+                [dropdownIcon]="disableDimensionDropdown ? '' : 'pi pi-chevron-down'"
                 (onChange)="onSelectedDimensionChange()" [autoWidth]="false" [style]="{'min-width':'10em'} ">
       <ng-template let-item pTemplate="selectedItem">
         <i class="{{getDimensionIcon(item.label)}} gb-dimension-icon"></i>&nbsp;{{item.label}}

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.spec.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.spec.ts
@@ -27,9 +27,9 @@ import {StudyService} from '../../../../services/study.service';
 import {StudyServiceMock} from '../../../../services/mocks/study.service.mock';
 import {AuthenticationService} from '../../../../services/authentication/authentication.service';
 import {AuthenticationServiceMock} from '../../../../services/mocks/authentication.service.mock';
-import {Constraint} from '../../../../models/constraint-models/constraint';
 import {Concept} from '../../../../models/constraint-models/concept';
 import {PedigreeConstraint} from '../../../../models/constraint-models/pedigree-constraint';
+import {CombinationState} from '../../../../models/constraint-models/combination-state';
 
 describe('GbCombinationConstraintComponent', () => {
   let component: GbCombinationConstraintComponent;
@@ -198,6 +198,25 @@ describe('GbCombinationConstraintComponent', () => {
     expect((<CombinationConstraint>children[0]).dimension).toBe('patient');
     expect((<CombinationConstraint>children[0]).children.length).toBe(1);
     expect((<CombinationConstraint>children[0]).children[0].className).toBe('PedigreeConstraint');
+  });
+
+  it('should disable dimension dropdown when root dimension selection is disabled', () => {
+
+    constraintService.rootDimensionSelectionDisabled = false;
+    expect(component.disableDimensionDropdown).toBe(false);
+
+    constraintService.rootDimensionSelectionDisabled = true;
+    constraintService.rootConstraint = new CombinationConstraint();
+    expect(component.disableDimensionDropdown).toBe(false);
+
+    let c1 = new ConceptConstraint();
+    c1.textRepresentation = 'foo';
+    constraintService.rootDimensionSelectionDisabled = true;
+    constraintService.rootConstraint = new CombinationConstraint([c1], CombinationState.And, 'diagnosis');
+    expect(component.disableDimensionDropdown).toBe(true);
+
+    component.updateDimensionDropdownOptions();
+    expect(component.disableDimensionDropdown).toBe(false);
   });
 
 });

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.spec.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.spec.ts
@@ -200,20 +200,18 @@ describe('GbCombinationConstraintComponent', () => {
     expect((<CombinationConstraint>children[0]).children[0].className).toBe('PedigreeConstraint');
   });
 
-  it('should disable dimension dropdown when root dimension selection is disabled', () => {
+  it('should restore constraints with subject dimensions', () => {
 
-    constraintService.dimensionSelectionDisabled = false;
-    expect(component.disableDimensionDropdown).toBe(false);
-
-    constraintService.dimensionSelectionDisabled = true;
-    constraintService.rootConstraint = new CombinationConstraint();
+    component.constraint = new CombinationConstraint();
+    component.updateDimensionDropdownOptions();
     expect(component.disableDimensionDropdown).toBe(false);
 
     let c1 = new ConceptConstraint();
     c1.textRepresentation = 'foo';
-    constraintService.dimensionSelectionDisabled = true;
+    c1.concept = new Concept();
+    c1.concept.subjectDimensions.push('diagnosis');
     component.constraint = new CombinationConstraint([c1], CombinationState.And, 'diagnosis');
-    constraintService.rootConstraint = <CombinationConstraint>component.constraint;
+    component.updateDimensionDropdownOptions();
     expect(component.disableDimensionDropdown).toBe(true);
 
     component.onConstraintRemoved(c1);

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.spec.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.spec.ts
@@ -202,20 +202,21 @@ describe('GbCombinationConstraintComponent', () => {
 
   it('should disable dimension dropdown when root dimension selection is disabled', () => {
 
-    constraintService.rootDimensionSelectionDisabled = false;
+    constraintService.dimensionSelectionDisabled = false;
     expect(component.disableDimensionDropdown).toBe(false);
 
-    constraintService.rootDimensionSelectionDisabled = true;
+    constraintService.dimensionSelectionDisabled = true;
     constraintService.rootConstraint = new CombinationConstraint();
     expect(component.disableDimensionDropdown).toBe(false);
 
     let c1 = new ConceptConstraint();
     c1.textRepresentation = 'foo';
-    constraintService.rootDimensionSelectionDisabled = true;
-    constraintService.rootConstraint = new CombinationConstraint([c1], CombinationState.And, 'diagnosis');
+    constraintService.dimensionSelectionDisabled = true;
+    component.constraint = new CombinationConstraint([c1], CombinationState.And, 'diagnosis');
+    constraintService.rootConstraint = <CombinationConstraint>component.constraint;
     expect(component.disableDimensionDropdown).toBe(true);
 
-    component.updateDimensionDropdownOptions();
+    component.onConstraintRemoved(c1);
     expect(component.disableDimensionDropdown).toBe(false);
   });
 

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.ts
@@ -68,6 +68,9 @@ export class GbCombinationConstraintComponent extends GbConstraintComponent impl
    */
   onConstraintRemoved(childConstraint: Constraint) {
     (<CombinationConstraint>this.constraint).removeChildConstraint(childConstraint);
+    if (this.constraintService.rootConstraint.children.length === 0) {
+      this.constraintService.dimensionSelectionDisabled = false;
+    }
     this.updateDimensionDropdownOptions();
     this.update();
   }
@@ -163,7 +166,6 @@ export class GbCombinationConstraintComponent extends GbConstraintComponent impl
   }
 
   updateDimensionDropdownOptions() {
-    this.constraintService.rootDimensionSelectionDisabled = false;
     let validDimensions = (<CombinationConstraint>this.constraint).validDimensions;
     if (validDimensions.length > 0) {
       this.dimensions = GbCombinationConstraintComponent.dimensionToDimensionOption(validDimensions);
@@ -199,7 +201,7 @@ export class GbCombinationConstraintComponent extends GbConstraintComponent impl
 
   get disableDimensionDropdown(): boolean {
     return this.dimensions.length === 1 ||
-      (this.constraintService.rootDimensionSelectionDisabled &&
+      (this.constraintService.dimensionSelectionDisabled &&
         !(this.constraintService.rootConstraint.children.length === 0)
       );
   }

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.ts
@@ -163,6 +163,7 @@ export class GbCombinationConstraintComponent extends GbConstraintComponent impl
   }
 
   updateDimensionDropdownOptions() {
+    this.constraintService.rootDimensionSelectionDisabled = false;
     let validDimensions = (<CombinationConstraint>this.constraint).validDimensions;
     if (validDimensions.length > 0) {
       this.dimensions = GbCombinationConstraintComponent.dimensionToDimensionOption(validDimensions);
@@ -194,6 +195,13 @@ export class GbCombinationConstraintComponent extends GbConstraintComponent impl
     return !(<CombinationConstraint>this.constraint).isRoot
       && this.constraint.parentConstraint
       && this.constraint.parentConstraint.className === 'PedigreeConstraint'
+  }
+
+  get disableDimensionDropdown(): boolean {
+    return this.dimensions.length === 1 ||
+      (this.constraintService.rootDimensionSelectionDisabled &&
+        !(this.constraintService.rootConstraint.children.length === 0)
+      );
   }
 
 }

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.ts
@@ -47,7 +47,7 @@ export class GbCombinationConstraintComponent extends GbConstraintComponent impl
 
   ngOnInit(): void {
     this.updateDimensionDropdownOptions();
-    this.constraintService.allSubjectDimensionsUpdated.asObservable().subscribe(() => {
+    this.constraintService.validSubjectDimensionsUpdated.asObservable().subscribe(() => {
       this.updateDimensionDropdownOptions();
       }
     );
@@ -68,9 +68,6 @@ export class GbCombinationConstraintComponent extends GbConstraintComponent impl
    */
   onConstraintRemoved(childConstraint: Constraint) {
     (<CombinationConstraint>this.constraint).removeChildConstraint(childConstraint);
-    if (this.constraintService.rootConstraint.children.length === 0) {
-      this.constraintService.dimensionSelectionDisabled = false;
-    }
     this.updateDimensionDropdownOptions();
     this.update();
   }
@@ -200,10 +197,7 @@ export class GbCombinationConstraintComponent extends GbConstraintComponent impl
   }
 
   get disableDimensionDropdown(): boolean {
-    return this.dimensions.length === 1 ||
-      (this.constraintService.dimensionSelectionDisabled &&
-        !(this.constraintService.rootConstraint.children.length === 0)
-      );
+    return this.dimensions.length === 1;
   }
 
 }

--- a/src/app/services/cohort.service.ts
+++ b/src/app/services/cohort.service.ts
@@ -80,12 +80,6 @@ export class CohortService {
     this.updateCountsWithCurrentCohort();
   }
 
-  clearAll(): Promise<any> {
-    this.constraintService.clearCohortConstraint();
-    this.isDirty = true;
-    return this.updateCountsWithCurrentCohort();
-  }
-
   /**
    * ----------------------------- Update the current cohort panel -----------------------------
    */

--- a/src/app/services/constraint.service.spec.ts
+++ b/src/app/services/constraint.service.spec.ts
@@ -94,7 +94,7 @@ describe('ConstraintService', () => {
   });
 
 
-  it('should restore cohort constraint with proper root dimenstion', () => {
+  it('should restore cohort constraint with proper root dimension', () => {
     let constraint1 = new CombinationConstraint();
     constraint1.dimension = 'diagnosis';
     let constraint11 = new ConceptConstraint();
@@ -102,10 +102,13 @@ describe('ConstraintService', () => {
 
     let constraint2 = new ConceptConstraint();
 
+    expect(constraintService.rootDimensionSelectionDisabled).toBe(false);
     constraintService.restoreCohortConstraint(constraint1);
     expect(constraintService.rootConstraint.dimension).toEqual('diagnosis');
+    expect(constraintService.rootDimensionSelectionDisabled).toBe(true);
 
     constraintService.restoreCohortConstraint(constraint2);
     expect(constraintService.rootConstraint.dimension).toEqual('patient');
+    expect(constraintService.rootDimensionSelectionDisabled).toBe(true);
   });
 });

--- a/src/app/services/constraint.service.spec.ts
+++ b/src/app/services/constraint.service.spec.ts
@@ -19,10 +19,8 @@ import {StudyConstraint} from '../models/constraint-models/study-constraint';
 import {Concept} from '../models/constraint-models/concept';
 import {TrueConstraint} from '../models/constraint-models/true-constraint';
 import {CombinationConstraint} from '../models/constraint-models/combination-constraint';
-import {Constraint} from '../models/constraint-models/constraint';
 import {CountServiceMock} from './mocks/count.service.mock';
 import {CountService} from './count.service';
-import {PedigreeConstraint} from '../models/constraint-models/pedigree-constraint';
 
 describe('ConstraintService', () => {
   let constraintService: ConstraintService;
@@ -93,22 +91,20 @@ describe('ConstraintService', () => {
       .toBe(1);
   });
 
-
-  it('should restore cohort constraint with proper root dimension', () => {
+  it('should restore cohort constraint with proper subject dimensions', () => {
+    let concept = new Concept();
     let constraint1 = new CombinationConstraint();
     constraint1.dimension = 'diagnosis';
     let constraint11 = new ConceptConstraint();
+    constraint11.concept = concept;
     constraint1.addChild(constraint11);
+    concept.subjectDimensions.push('diagnosis');
+    constraintService.concepts.push(concept);
 
-    let constraint2 = new ConceptConstraint();
-
-    expect(constraintService.dimensionSelectionDisabled).toBe(false);
     constraintService.restoreCohortConstraint(constraint1);
     expect(constraintService.rootConstraint.dimension).toEqual('diagnosis');
-    expect(constraintService.dimensionSelectionDisabled).toBe(true);
-
-    constraintService.restoreCohortConstraint(constraint2);
-    expect(constraintService.rootConstraint.dimension).toEqual('patient');
-    expect(constraintService.dimensionSelectionDisabled).toBe(true);
+    expect((<ConceptConstraint>constraintService.rootConstraint.children[0]).concept.subjectDimensions)
+      .toContain('diagnosis');
   });
+
 });

--- a/src/app/services/constraint.service.spec.ts
+++ b/src/app/services/constraint.service.spec.ts
@@ -102,13 +102,13 @@ describe('ConstraintService', () => {
 
     let constraint2 = new ConceptConstraint();
 
-    expect(constraintService.rootDimensionSelectionDisabled).toBe(false);
+    expect(constraintService.dimensionSelectionDisabled).toBe(false);
     constraintService.restoreCohortConstraint(constraint1);
     expect(constraintService.rootConstraint.dimension).toEqual('diagnosis');
-    expect(constraintService.rootDimensionSelectionDisabled).toBe(true);
+    expect(constraintService.dimensionSelectionDisabled).toBe(true);
 
     constraintService.restoreCohortConstraint(constraint2);
     expect(constraintService.rootConstraint.dimension).toEqual('patient');
-    expect(constraintService.rootDimensionSelectionDisabled).toBe(true);
+    expect(constraintService.dimensionSelectionDisabled).toBe(true);
   });
 });

--- a/src/app/services/constraint.service.ts
+++ b/src/app/services/constraint.service.ts
@@ -57,7 +57,7 @@ export class ConstraintService {
    * The maximum number of search results allowed when searching for a constraint
    */
   private _maxNumSearchResults = 100;
-  private _rootDimensionSelectionDisabled: boolean;
+  private _dimensionSelectionDisabled: boolean;
 
   constructor(private treeNodeService: TreeNodeService,
               private studyService: StudyService,
@@ -67,7 +67,7 @@ export class ConstraintService {
     // Initialize the root constraints in the cohort selection
     this.rootConstraint = new CombinationConstraint();
     this.rootConstraint.isRoot = true;
-    this.rootDimensionSelectionDisabled = false;
+    this.dimensionSelectionDisabled = false;
 
     // Construct constraints
     this.loadEmptyConstraints();
@@ -227,7 +227,7 @@ export class ConstraintService {
       this.rootConstraint.dimension = CombinationConstraint.TOP_LEVEL_DIMENSION;
       this.rootConstraint.addChild(constraint);
     }
-    this.rootDimensionSelectionDisabled = true;
+    this.dimensionSelectionDisabled = true;
   }
 
   /*
@@ -307,11 +307,11 @@ export class ConstraintService {
     return this._allSubjectDimensionsUpdated;
   }
 
-  get rootDimensionSelectionDisabled(): boolean {
-    return this._rootDimensionSelectionDisabled;
+  get dimensionSelectionDisabled(): boolean {
+    return this._dimensionSelectionDisabled;
   }
 
-  set rootDimensionSelectionDisabled(value: boolean) {
-    this._rootDimensionSelectionDisabled = value;
+  set dimensionSelectionDisabled(value: boolean) {
+    this._dimensionSelectionDisabled = value;
   }
 }

--- a/src/app/services/constraint.service.ts
+++ b/src/app/services/constraint.service.ts
@@ -57,6 +57,7 @@ export class ConstraintService {
    * The maximum number of search results allowed when searching for a constraint
    */
   private _maxNumSearchResults = 100;
+  private _rootDimensionSelectionDisabled: boolean;
 
   constructor(private treeNodeService: TreeNodeService,
               private studyService: StudyService,
@@ -66,6 +67,7 @@ export class ConstraintService {
     // Initialize the root constraints in the cohort selection
     this.rootConstraint = new CombinationConstraint();
     this.rootConstraint.isRoot = true;
+    this.rootDimensionSelectionDisabled = false;
 
     // Construct constraints
     this.loadEmptyConstraints();
@@ -225,6 +227,7 @@ export class ConstraintService {
       this.rootConstraint.dimension = CombinationConstraint.TOP_LEVEL_DIMENSION;
       this.rootConstraint.addChild(constraint);
     }
+    this.rootDimensionSelectionDisabled = true;
   }
 
   /*
@@ -302,5 +305,13 @@ export class ConstraintService {
 
   get allSubjectDimensionsUpdated(): Subject<Dimension[]> {
     return this._allSubjectDimensionsUpdated;
+  }
+
+  get rootDimensionSelectionDisabled(): boolean {
+    return this._rootDimensionSelectionDisabled;
+  }
+
+  set rootDimensionSelectionDisabled(value: boolean) {
+    this._rootDimensionSelectionDisabled = value;
   }
 }

--- a/src/app/services/mocks/cohort.service.mock.ts
+++ b/src/app/services/mocks/cohort.service.mock.ts
@@ -31,10 +31,6 @@ export class CohortServiceMock {
     });
   }
 
-  clearAll(): Promise<any> {
-    return new Promise<any>(resolve => resolve(true));
-  }
-
   get cohorts(): Cohort[] {
     return this._cohorts;
   }

--- a/src/app/services/mocks/constraint.service.mock.ts
+++ b/src/app/services/mocks/constraint.service.mock.ts
@@ -27,6 +27,7 @@ export class ConstraintServiceMock {
   private _constraint: Constraint = new CombinationConstraint();
   private _allSubjectDimensionsUpdated: Subject<Cohort[]> = new Subject<Cohort[]>();
   private _allSubjectDimensions: Dimension[] = [];
+  private _rootDimensionSelectionDisabled = false;
   constructor() {
     this._rootConstraint = new CombinationConstraint();
   }
@@ -113,5 +114,14 @@ export class ConstraintServiceMock {
   set allSubjectDimensions(value: Dimension[]) {
     this._allSubjectDimensions = value;
   }
+
+  get rootDimensionSelectionDisabled(): boolean {
+    return this._rootDimensionSelectionDisabled;
+  }
+
+  set rootDimensionSelectionDisabled(value: boolean) {
+    this._rootDimensionSelectionDisabled = value;
+  }
+
 
 }

--- a/src/app/services/mocks/constraint.service.mock.ts
+++ b/src/app/services/mocks/constraint.service.mock.ts
@@ -25,9 +25,8 @@ export class ConstraintServiceMock {
   private _conceptConstraints: Constraint[] = [];
   private _maxNumSearchResults = 100;
   private _constraint: Constraint = new CombinationConstraint();
-  private _allSubjectDimensionsUpdated: Subject<Cohort[]> = new Subject<Cohort[]>();
+  private _validSubjectDimensionsUpdated: Subject<Cohort[]> = new Subject<Cohort[]>();
   private _allSubjectDimensions: Dimension[] = [];
-  private _dimensionSelectionDisabled = false;
   constructor() {
     this._rootConstraint = new CombinationConstraint();
   }
@@ -99,12 +98,12 @@ export class ConstraintServiceMock {
     this._maxNumSearchResults = value;
   }
 
-  get allSubjectDimensionsUpdated(): Subject<Cohort[]> {
-    return this._allSubjectDimensionsUpdated;
+  get validSubjectDimensionsUpdated(): Subject<Cohort[]> {
+    return this._validSubjectDimensionsUpdated;
   }
 
-  set allSubjectDimensionsUpdated(value: Subject<Cohort[]>) {
-    this._allSubjectDimensionsUpdated = value;
+  set validSubjectDimensionsUpdated(value: Subject<Cohort[]>) {
+    this._validSubjectDimensionsUpdated = value;
   }
 
   get allSubjectDimensions(): Dimension[] {
@@ -114,14 +113,5 @@ export class ConstraintServiceMock {
   set allSubjectDimensions(value: Dimension[]) {
     this._allSubjectDimensions = value;
   }
-
-  get dimensionSelectionDisabled(): boolean {
-    return this._dimensionSelectionDisabled;
-  }
-
-  set dimensionSelectionDisabled(value: boolean) {
-    this._dimensionSelectionDisabled = value;
-  }
-
 
 }

--- a/src/app/services/mocks/constraint.service.mock.ts
+++ b/src/app/services/mocks/constraint.service.mock.ts
@@ -27,7 +27,7 @@ export class ConstraintServiceMock {
   private _constraint: Constraint = new CombinationConstraint();
   private _allSubjectDimensionsUpdated: Subject<Cohort[]> = new Subject<Cohort[]>();
   private _allSubjectDimensions: Dimension[] = [];
-  private _rootDimensionSelectionDisabled = false;
+  private _dimensionSelectionDisabled = false;
   constructor() {
     this._rootConstraint = new CombinationConstraint();
   }
@@ -115,12 +115,12 @@ export class ConstraintServiceMock {
     this._allSubjectDimensions = value;
   }
 
-  get rootDimensionSelectionDisabled(): boolean {
-    return this._rootDimensionSelectionDisabled;
+  get dimensionSelectionDisabled(): boolean {
+    return this._dimensionSelectionDisabled;
   }
 
-  set rootDimensionSelectionDisabled(value: boolean) {
-    this._rootDimensionSelectionDisabled = value;
+  set dimensionSelectionDisabled(value: boolean) {
+    this._dimensionSelectionDisabled = value;
   }
 
 

--- a/src/tests/cohort.integration.spec.ts
+++ b/src/tests/cohort.integration.spec.ts
@@ -212,20 +212,6 @@ describe('Integration test for cohort saving and restoring', () => {
     expect(spySave).toHaveBeenCalled();
   });
 
-  it('should clear cohorts in relation to other dependent services', () => {
-    treeNodeService.treeNodeCallsSent = 10;
-    treeNodeService.treeNodeCallsReceived = 10;
-    cohortService.restoreCohort(q0)
-      .then(() => {
-        cohortService.clearAll()
-          .then(() => {
-            expect(constraintService.rootConstraint.children.length).toBe(0);
-            expect(cohortService.isDirty).toBe(false);
-          });
-        expect(cohortService.isDirty).toBe(true);
-      });
-  });
-
   it('should restore cohort containing subject set constraint', () => {
     let target = new Cohort(null, 'test');
     let subjectSetConstraint = new SubjectSetConstraint();


### PR DESCRIPTION
Fixes [TMT-862](https://jira.thehyve.nl/browse/TMT-862) - when restoring a cohort, the dimension button should be locked.

Additionally, remove unused code in the cohort service.