### PR TITLE
Fix auto-adjusting cross table height and the drop-zone place

### DIFF
--- a/src/app/modules/gb-analysis-module/cross-table-components/gb-droppable-zone/gb-droppable-zone.component.html
+++ b/src/app/modules/gb-analysis-module/cross-table-components/gb-droppable-zone/gb-droppable-zone.component.html
@@ -2,7 +2,8 @@
      class="container gb-droppable-zone-container"
      [ngClass]="{'gb-droppable-zone-container-highlight': dragCounter > 0}"
      (onDragEnter)="onDragEnter($event)"
-     (onDragLeave)="onDragLeave($event)">
+     (onDragLeave)="onDragLeave($event)"
+     (drop)="onDrop($event)">
 
   <div class="row">
     <div *ngFor="let constraint of constraints"
@@ -12,7 +13,7 @@
       </gb-draggable-cell>
     </div>
     <div *ngIf="constraints.length === 0"
-          class="gb-droppable-zone-info-container" (drop)="onDrop($event)">
+          class="gb-droppable-zone-info-container">
       <span *ngIf="axis == 'Row'">
         Row drop zone
       </span>

--- a/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-chart/gb-fractalis-chart.component.spec.ts
+++ b/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-chart/gb-fractalis-chart.component.spec.ts
@@ -53,7 +53,7 @@ describe('GbFractalisChartComponent', () => {
     fixture.detectChanges();
     expect(component).toBeTruthy();
     expect(component.chartWidth).toEqual('35em');
-    expect(component.chartHeight).toEqual('17.5em');
+    expect(component.chartHeight).toEqual('auto');
   });
 
   const mockFractalisTaskData: FractalisData[] = [

--- a/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-chart/gb-fractalis-chart.component.ts
+++ b/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-chart/gb-fractalis-chart.component.ts
@@ -100,9 +100,8 @@ export class GbFractalisChartComponent implements AfterViewInit {
   }
 
   get chartHeight(): string {
-    let size = this.chart.type === ChartType.CROSSTABLE ? this.fractalisService.chartDivSize / 2 :
-      this.fractalisService.chartDivSize;
-    return size + 'em';
+    return this.chart.type === ChartType.CROSSTABLE ? 'auto' :
+      this.fractalisService.chartDivSize + 'em';
   }
 
 }


### PR DESCRIPTION
Issues:
- cross table height was fixed. When number of items was > 6, they were not displayed as the rows.
- the drop area was limited to the text area for both rows and columns - this caused issues, like redirecting to data.com on Firefox or not showing the actual items.

Fixes: [TMT-922](https://jira.thehyve.nl/browse/TMT-922), [TMT-361](https://jira.thehyve.nl/browse/TMT-361)