### PR TITLE
Change the description of negation on observation constraints.

### DIFF
--- a/cypress/support/step_definitions/constraint-creation.js
+++ b/cypress/support/step_definitions/constraint-creation.js
@@ -87,7 +87,7 @@ when("I use public study {string} and negation of study {string} as a constraint
 then("constraint panel containing {string} is negated", (constraintName) => {
   cy.get('.gb-constraint-container').contains(constraintName).parents('.gb-negated-constraint');
   cy.get('span').contains('excluding').should('be.visible');
-  cy.get('label').contains('for the patient there is NO observation:');
+  cy.get('label').contains('for the patient there is an observation other than observations:');
 });
 
 when("I use negated pedigree constraint {string} with concept {string} and negated concept {string}",

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-constraint/gb-constraint.component.spec.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-constraint/gb-constraint.component.spec.ts
@@ -152,7 +152,7 @@ describe('GbConstraintComponent', () => {
     expect(component.observationBoxMessage).toBe('for the patient there is an observation:');
 
     component.constraint.negated = true;
-    expect(component.observationBoxMessage).toBe('for the patient there is NO observation:');
+    expect(component.observationBoxMessage).toBe('for the patient there is an observation other than observations:');
   });
 
 });

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-constraint/gb-constraint.component.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-constraint/gb-constraint.component.ts
@@ -98,7 +98,7 @@ export class GbConstraintComponent implements OnInit {
   get observationBoxMessage(): string {
     let parentDimension = this.constraint.parentDimension;
     if (this.constraint.negated) {
-      return `for the ${parentDimension} there is NO observation:`;
+      return `for the ${parentDimension} there is an observation other than observations:`;
     } else {
       return `for the ${parentDimension} there is an observation:`;
     }


### PR DESCRIPTION
Negation on observations constraints is complicated when using
nested subject dimension subselects. It does not trigger an
existential constraint (for this dimension element no observation
such and such exists), but it inverts the observation selection
(for this dimension an observation exists that does not match
these criteria).