### PR TITLE
Fix ensuring patient-level constraint for non-combination constraints

### DIFF
--- a/src/app/utilities/constraint-utilities/constraint-helper.spec.ts
+++ b/src/app/utilities/constraint-utilities/constraint-helper.spec.ts
@@ -83,3 +83,35 @@ describe('ConstraintHelper.hasNonEmptyChildren', () => {
   });
 
 });
+
+describe('ConstraintHelper.ensurePatientLevelConstraint', () => {
+
+  it('should wrap combination selecting samples into patient subselection', () => {
+    let sampleLevelCombination = new CombinationConstraint();
+    sampleLevelCombination.dimension = 'sample-dimension';
+    let resultConstraint = ConstraintHelper.ensurePatientLevelConstraint(sampleLevelCombination);
+    expect(resultConstraint).toEqual(jasmine.any(CombinationConstraint));
+    expect((resultConstraint as CombinationConstraint).dimension).toEqual('patient');
+    expect(((resultConstraint as CombinationConstraint).children[0] as CombinationConstraint).dimension)
+      .toEqual('sample-dimension');
+  });
+
+  it('should wrap non-combination constraint into patient subselection', () => {
+    let conceptConstraint = new ConceptConstraint();
+    let resultConstraint = ConstraintHelper.ensurePatientLevelConstraint(conceptConstraint);
+    expect(resultConstraint).toEqual(jasmine.any(CombinationConstraint));
+    expect((resultConstraint as CombinationConstraint).dimension).toEqual('patient');
+    expect((resultConstraint as CombinationConstraint).children[0]).toEqual(jasmine.any(ConceptConstraint));
+  });
+
+  it('should not wrap combination selecting patients into patient subselection', () => {
+    let patientLevelCombination = new CombinationConstraint();
+    patientLevelCombination.dimension = 'patient';
+    patientLevelCombination.addChild(new ConceptConstraint());
+    let resultConstraint = ConstraintHelper.ensurePatientLevelConstraint(patientLevelCombination);
+    expect(resultConstraint).toEqual(jasmine.any(CombinationConstraint));
+    expect((resultConstraint as CombinationConstraint).dimension).toEqual('patient');
+    expect((resultConstraint as CombinationConstraint).children[0]).toEqual(jasmine.any(ConceptConstraint));
+  });
+
+});

--- a/src/app/utilities/constraint-utilities/constraint-helper.ts
+++ b/src/app/utilities/constraint-utilities/constraint-helper.ts
@@ -89,7 +89,8 @@ export class ConstraintHelper {
    */
   static ensurePatientLevelConstraint(observationConstraint: Constraint): Constraint {
     if (observationConstraint.className === 'CombinationConstraint' &&
-      (<CombinationConstraint>observationConstraint).dimension !== 'patient') {
+      (<CombinationConstraint>observationConstraint).dimension !== 'patient'
+      || observationConstraint.className !== 'CombinationConstraint') {
       return new CombinationConstraint([observationConstraint], CombinationState.And, 'patient');
     }
     return observationConstraint;

--- a/src/tests/cohort.integration.spec.ts
+++ b/src/tests/cohort.integration.spec.ts
@@ -29,7 +29,6 @@ import {CountService} from '../app/services/count.service';
 import {TransmartAndConstraint, TransmartNegationConstraint} from '../app/models/transmart-models/transmart-constraint';
 import {CohortMapper} from '../app/utilities/cohort-utilities/cohort-mapper';
 import {CohortRepresentation} from '../app/models/gb-backend-models/cohort-representation';
-import {ConstraintHelper} from '../app/utilities/constraint-utilities/constraint-helper';
 
 describe('Integration test for cohort saving and restoring', () => {
 
@@ -222,23 +221,6 @@ describe('Integration test for cohort saving and restoring', () => {
       .catch(err => {
         fail('should have successfully restored the cohort with subject-set constraint but not')
       });
-  });
-
-  it('should ensure patient level constraint before updating counts', () => {
-    let spy1 = spyOn(ConstraintHelper, 'ensurePatientLevelConstraint').and.callThrough();
-    let spy2 = spyOn(countService, 'updateAllCounts').and.callThrough();
-    let spy3 = spyOn(resourceService, 'getCountsPerConcept').and.callThrough();
-
-    cohortService.cohorts = [new Cohort('test', 'test')];
-    cohortService.cohorts[0].selected = true;
-    cohortService.cohorts[0].constraint = new ConceptConstraint();
-
-    let promise = cohortService.updateCountsWithAllCohorts();
-    promise.then(() => {
-      expect(spy1).toHaveBeenCalled();
-      expect(spy2).toHaveBeenCalledWith(jasmine.any(ConceptConstraint));
-      expect(spy3).toHaveBeenCalledWith(jasmine.any(CombinationConstraint));
-    });
   });
 
   it('should save subject set before updating counts', () => {


### PR DESCRIPTION
Fixes [TMT-987](https://jira.thehyve.nl/browse/TMT-987) - missing variables in variables panel, when selecting single cohort with concept constraint