### PR TITLE
Revert change of description of negation on observation constraints.

### DIFF
--- a/cypress/support/step_definitions/constraint-creation.js
+++ b/cypress/support/step_definitions/constraint-creation.js
@@ -87,7 +87,7 @@ when("I use public study {string} and negation of study {string} as a constraint
 then("constraint panel containing {string} is negated", (constraintName) => {
   cy.get('.gb-constraint-container').contains(constraintName).parents('.gb-negated-constraint');
   cy.get('span').contains('excluding').should('be.visible');
-  cy.get('label').contains('for the patient there is an observation other than observations:');
+  cy.get('label').contains('for the patient there is NO observation:');
 });
 
 when("I use negated pedigree constraint {string} with concept {string} and negated concept {string}",

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-constraint/gb-constraint.component.spec.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-constraint/gb-constraint.component.spec.ts
@@ -152,7 +152,7 @@ describe('GbConstraintComponent', () => {
     expect(component.observationBoxMessage).toBe('for the patient there is an observation:');
 
     component.constraint.negated = true;
-    expect(component.observationBoxMessage).toBe('for the patient there is an observation other than observations:');
+    expect(component.observationBoxMessage).toBe('for the patient there is NO observation:');
   });
 
 });

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-constraint/gb-constraint.component.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-constraint/gb-constraint.component.ts
@@ -98,7 +98,7 @@ export class GbConstraintComponent implements OnInit {
   get observationBoxMessage(): string {
     let parentDimension = this.constraint.parentDimension;
     if (this.constraint.negated) {
-      return `for the ${parentDimension} there is an observation other than observations:`;
+      return `for the ${parentDimension} there is NO observation:`;
     } else {
       return `for the ${parentDimension} there is an observation:`;
     }


### PR DESCRIPTION
After the fix of dimension subselection of 80a5089,
the description change of 1460956 is not applicable anymore.

Fixes [TMT-1006](https://jira.thehyve.nl/browse/TMT-1006).
Reverts commit 1460956.