### PR TITLE
Cross table improvements

### DIFF
--- a/src/app/models/table-models/cross-table.ts
+++ b/src/app/models/table-models/cross-table.ts
@@ -15,14 +15,14 @@ export class CrossTable {
   // the base constraint that the row/col constraints are conditioned on
   private _constraint: Constraint;
   // the row and column constraints used in the drag & drop zones
-  private _rowConstraints: Array<Constraint> = [];
-  private _columnConstraints: Array<Constraint> = [];
+  private _rowConstraints: Constraint[] = [];
+  private _columnConstraints: Constraint[] = [];
   /*
    * the keys of the value constraints are the row/column constraints,
    * a value constraint is typically a categorical value constraint,
    * sometimes combined with a study constraint
    */
-  private _valueConstraints: Map<Constraint, Array<Constraint>>;
+  private _valueConstraints: Map<Constraint, Constraint[]>;
   /*
    * the header constraints used as input params for backend call
    */
@@ -37,15 +37,15 @@ export class CrossTable {
    * _rows[3] ------> _rows[3].data[_col[0]], _rows[3].data[_col[1]], _rows[3].data[_col[2]], ...
    */
   // The actual rows
-  private _rows: Array<Row> = [];
+  private _rows: Row[] = [];
   // The index top row
-  private _cols: Array<Col> = [];
+  private _cols: Col[] = [];
   // Flag indicating is the cross table is updating
   private _isUpdating: boolean;
 
   constructor() {
     this.constraint = new TrueConstraint();
-    this.valueConstraints = new Map<Constraint, Array<Constraint>>();
+    this.valueConstraints = new Map<Constraint, Constraint[]>();
     this.isUpdating = false;
   }
 
@@ -56,43 +56,43 @@ export class CrossTable {
     this.valueConstraints.set(keyConstraint, valueConstraints);
   }
 
-  get rowConstraints(): Array<Constraint> {
+  get rowConstraints(): Constraint[] {
     return this._rowConstraints;
   }
 
-  set rowConstraints(value: Array<Constraint>) {
+  set rowConstraints(value: Constraint[]) {
     this._rowConstraints = value;
   }
 
-  get columnConstraints(): Array<Constraint> {
+  get columnConstraints(): Constraint[] {
     return this._columnConstraints;
   }
 
-  set columnConstraints(value: Array<Constraint>) {
+  set columnConstraints(value: Constraint[]) {
     this._columnConstraints = value;
   }
 
-  get rows(): Array<Row> {
+  get rows(): Row[] {
     return this._rows;
   }
 
-  set rows(value: Array<Row>) {
+  set rows(value: Row[]) {
     this._rows = value;
   }
 
-  get cols(): Array<Col> {
+  get cols(): Col[] {
     return this._cols;
   }
 
-  set cols(value: Array<Col>) {
+  set cols(value: Col[]) {
     this._cols = value;
   }
 
-  get valueConstraints(): Map<Constraint, Array<Constraint>> {
+  get valueConstraints(): Map<Constraint, Constraint[]> {
     return this._valueConstraints;
   }
 
-  set valueConstraints(value: Map<Constraint, Array<Constraint>>) {
+  set valueConstraints(value: Map<Constraint, Constraint[]>) {
     this._valueConstraints = value;
   }
 

--- a/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.html
+++ b/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.html
@@ -2,34 +2,25 @@
 
   <!-- Header and description -->
   <div class="description">
-    Cross Table
+    Cross table
     <i class="fa fa-info"
-       matTooltip='Drag categorical variables from the "Variables" section on the left
-       into the "drop zones" below to see the intersection counts.'
-       aria-label="Tooltip on how to use Cross Table"></i>
+       matTooltip="Drag categorical variables from the &lsquo;Variables&rsquo; section on the left
+       into the &lsquo;drop zones&rsquo; below to create rows and columns of groups of patients
+       for different values. The table displays the patient count of the intersection of these groups."
+       aria-label="Tooltip on how to use the cross table"></i>
   </div>
-
-  <p-overlayPanel #gb_cross_table_info
-                  [dismissable]="true"
-                  [showCloseIcon]="false"
-                  [style]="{'background':'#339C90', 'width': '50%'}">
-    <div class="info-text">
-      Create a cross table by dragging categorical tree nodes, in the "Current Data Selection" panel on the left side,
-      into the drop zones below.
-    </div>
-  </p-overlayPanel>
 
   <!-- The cross table -->
   <div class="row" style="margin-bottom: 10px">
     <div class="col-md-3"></div>
     <div class="col-md-9">
-      <gb-droppable-zone [constraints]="columnConstraints" axis="Column"></gb-droppable-zone>
+      <gb-droppable-zone [disabled]="isUpdating" [constraints]="columnConstraints" axis="Column"></gb-droppable-zone>
     </div>
   </div>
 
   <div class="row">
     <div class="col-md-3">
-      <gb-droppable-zone [constraints]="rowConstraints" axis="Row"></gb-droppable-zone>
+      <gb-droppable-zone [disabled]="isUpdating" [constraints]="rowConstraints" axis="Row"></gb-droppable-zone>
     </div>
     <div class="col-md-9">
       <!-- when the table is still updating -->
@@ -37,18 +28,7 @@
 
       <!-- when the table finished updating, the table content goes here -->
       <div *ngIf="!isUpdating">
-        <p-table [value]="rows" [columns]="cols" [resizableColumns]="true" [customSort]="true">
-          <ng-template pTemplate="header" let-columns>
-            <tr>
-              <th *ngFor="let col of columns" pResizableColumn
-                  class="top-header"
-                  style="color: transparent">
-              <span>
-                {{col.header}}
-              </span>
-              </th>
-            </tr>
-          </ng-template>
+        <p-table [autoLayout]="true" [value]="rows" [columns]="cols" [customSort]="true">
 
           <!-- table body -->
           <ng-template pTemplate="body" let-row let-columns="columns">

--- a/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.html
+++ b/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.html
@@ -14,13 +14,13 @@
   <div class="row" style="margin-bottom: 10px">
     <div class="col-md-3"></div>
     <div class="col-md-9">
-      <gb-droppable-zone [disabled]="isUpdating" [constraints]="columnConstraints" axis="Column"></gb-droppable-zone>
+      <gb-droppable-zone [disabled]="isUpdating" [constraints]="columnConstraints" [axis]="AxisType.COL"></gb-droppable-zone>
     </div>
   </div>
 
   <div class="row">
     <div class="col-md-3">
-      <gb-droppable-zone [disabled]="isUpdating" [constraints]="rowConstraints" axis="Row"></gb-droppable-zone>
+      <gb-droppable-zone [disabled]="isUpdating" [constraints]="rowConstraints" [axis]="AxisType.ROW"></gb-droppable-zone>
     </div>
     <div class="col-md-9">
       <!-- when the table is still updating -->

--- a/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.spec.ts
+++ b/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.spec.ts
@@ -37,7 +37,7 @@ describe('GbCrossTableComponent', () => {
       ],
       declarations: [
         GbCrossTableComponent,
-        MockComponent({selector: 'gb-droppable-zone', inputs: ['constraints']})
+        MockComponent({selector: 'gb-droppable-zone', inputs: ['constraints', 'axis', 'disabled']})
       ]
     })
       .compileComponents();

--- a/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.ts
+++ b/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.ts
@@ -12,6 +12,7 @@ import {Constraint} from '../../../../models/constraint-models/constraint';
 import {Row} from '../../../../models/table-models/row';
 import {Col} from '../../../../models/table-models/col';
 import {FormatHelper} from '../../../../utilities/format-helper';
+import {AxisType} from '../../../../models/table-models/axis-type';
 
 @Component({
   selector: 'gb-cross-table',
@@ -22,6 +23,8 @@ import {FormatHelper} from '../../../../utilities/format-helper';
   encapsulation: ViewEncapsulation.None
 })
 export class GbCrossTableComponent implements OnInit {
+
+  AxisType = AxisType;
 
   constructor(private crossTableService: CrossTableService) {
   }

--- a/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.ts
+++ b/src/app/modules/gb-analysis-module/cross-table-components/gb-cross-table/gb-cross-table.component.ts
@@ -37,11 +37,11 @@ export class GbCrossTableComponent implements OnInit {
     return this.crossTableService.columnConstraints;
   }
 
-  get rows(): Array<Row> {
+  get rows(): Row[] {
     return this.crossTableService.rows;
   }
 
-  get cols(): Array<Col> {
+  get cols(): Col[] {
     return this.crossTableService.cols;
   }
 

--- a/src/app/modules/gb-analysis-module/cross-table-components/gb-droppable-zone/gb-droppable-zone.component.ts
+++ b/src/app/modules/gb-analysis-module/cross-table-components/gb-droppable-zone/gb-droppable-zone.component.ts
@@ -22,7 +22,7 @@ import {ConstraintSerialiser} from '../../../../utilities/constraint-utilities/c
   styleUrls: ['./gb-droppable-zone.component.css']
 })
 export class GbDroppableZoneComponent implements OnInit {
-  @Input() constraints: Array<Constraint> = [];
+  @Input() constraints: Constraint[] = [];
   @Input() axis: AxisType = null;
 
   public dragCounter = 0;
@@ -97,7 +97,6 @@ export class GbDroppableZoneComponent implements OnInit {
 
   /**
    * Remove the selected constraint from the list
-   * @param {any} onlyUpdateHeaders - indicate if to update the cells or just the headers
    * @param {Constraint} constraint
    */
   onConstraintCellRemoved(constraint: Constraint) {

--- a/src/app/modules/gb-analysis-module/cross-table-components/gb-droppable-zone/gb-droppable-zone.component.ts
+++ b/src/app/modules/gb-analysis-module/cross-table-components/gb-droppable-zone/gb-droppable-zone.component.ts
@@ -24,6 +24,7 @@ import {ConstraintSerialiser} from '../../../../utilities/constraint-utilities/c
 export class GbDroppableZoneComponent implements OnInit {
   @Input() constraints: Constraint[] = [];
   @Input() axis: AxisType = null;
+  @Input() disabled = false;
 
   public dragCounter = 0;
 
@@ -61,7 +62,9 @@ export class GbDroppableZoneComponent implements OnInit {
     let constraint = selectedConstraintCell ? selectedConstraintCell.constraint : null;
     // if no existing constraint (from one of the already created draggable cells) is used,
     // try to create a new one based on the (possible) variable drop
-    if (!constraint) {
+    if (this.disabled) {
+      // do nothing, data loading is in progress
+    } else if (!constraint) {
       let variable = this.variableService.identifyDraggedElement();
       if (variable) {
         constraint = new ConceptConstraint();

--- a/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-control/gb-fractalis-control.component.ts
+++ b/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-control/gb-fractalis-control.component.ts
@@ -85,7 +85,8 @@ export class GbFractalisControlComponent implements OnInit {
     let shown = false;
     if (this.selectedChartType) {
       if (this.selectedChartType === ChartType.CROSSTABLE) {
-        shown = true;
+        // only enable adding a cross table if there is not one already.
+        shown = !this.fractalisService.charts.some(chart => chart.type === ChartType.CROSSTABLE);
       } else if (this.selectedVariables.length > 0) {
         shown = true;
       }

--- a/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-control/gb-fractalis-control.component.ts
+++ b/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-control/gb-fractalis-control.component.ts
@@ -95,7 +95,7 @@ export class GbFractalisControlComponent implements OnInit {
   }
 
   get isClearButtonShown(): boolean {
-    return this.selectedChartType ? true : false;
+    return this.fractalisService.isFractalisEnabled && !!this.selectedChartType;
   }
 
   get selectedChartType(): ChartType {

--- a/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-visual/gb-fractalis-visual.component.css
+++ b/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-visual/gb-fractalis-visual.component.css
@@ -4,7 +4,7 @@
   height: auto;
 }
 
-.fractatis-chart-hidden {
+.fractalis-chart-hidden {
   display: none;
 }
 

--- a/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-visual/gb-fractalis-visual.component.html
+++ b/src/app/modules/gb-analysis-module/fractalis-components/gb-fractalis-visual/gb-fractalis-visual.component.html
@@ -8,7 +8,7 @@
 
   <div class="charts">
     <div *ngFor="let chart of charts">
-      <span [ngClass]="{'fractatis-chart-hidden': !chart.isValid}">
+      <span [ngClass]="{'fractalis-chart-hidden': !chart.isValid}">
         <button mat-icon-button color="primary" (click)="onRemoveChart($event, chart)">
           <mat-icon aria-label="Close the chart">close</mat-icon>
         </button>

--- a/src/app/modules/gb-analysis-module/gb-analysis.component.css
+++ b/src/app/modules/gb-analysis-module/gb-analysis.component.css
@@ -4,6 +4,10 @@
   padding: 0.5em;
 }
 
+.visual-panel {
+  overflow-x: auto;
+}
+
 :host >>> .section-banner {
   color: gray;
   padding: 0px;

--- a/src/app/modules/gb-analysis-module/gb-analysis.component.html
+++ b/src/app/modules/gb-analysis-module/gb-analysis.component.html
@@ -22,7 +22,9 @@
         </mat-panel-title>
       </mat-expansion-panel-header>
 
-      <gb-fractalis-visual></gb-fractalis-visual>
+      <div class="visual-panel">
+        <gb-fractalis-visual></gb-fractalis-visual>
+      </div>
     </mat-expansion-panel>
   </mat-accordion>
 

--- a/src/app/services/cross-table.service.ts
+++ b/src/app/services/cross-table.service.ts
@@ -60,9 +60,9 @@ export class CrossTableService {
 
   /**
    * Update the cross table given row/column constraints
-   * @param {Array<Constraint>} constraints
+   * @param {Constraint[]} constraints
    */
-  public update(constraints: Array<Constraint>): Promise<any> {
+  public update(constraints: Constraint[]): Promise<any> {
     return new Promise((resolve, reject) => {
       this.crossTable.isUpdating = true;
       this.updateValueConstraints(constraints)
@@ -98,9 +98,9 @@ export class CrossTableService {
    * since the value constraints will be recreated and old pointers are lost,
    * the cells of the table will also be renewed
    *
-   * @param {Array<Constraint>} constraints - the row/column constraints of the cross table
+   * @param {Constraint[]} constraints - the row/column constraints of the cross table
    */
-  private updateValueConstraints(constraints: Array<Constraint>): Promise<any> {
+  private updateValueConstraints(constraints: Constraint[]): Promise<any> {
     return new Promise((resolve, reject) => {
       // clear existing value constraints
       this.clearValueConstraints(constraints);
@@ -270,15 +270,15 @@ export class CrossTableService {
     this._selectedConstraintCell = value;
   }
 
-  get rowConstraints(): Array<Constraint> {
+  get rowConstraints(): Constraint[] {
     return this.crossTable.rowConstraints;
   }
 
-  get columnConstraints(): Array<Constraint> {
+  get columnConstraints(): Constraint[] {
     return this.crossTable.columnConstraints;
   }
 
-  get valueConstraints(): Map<Constraint, Array<Constraint>> {
+  get valueConstraints(): Map<Constraint, Constraint[]> {
     return this.crossTable.valueConstraints;
   }
 
@@ -296,10 +296,6 @@ export class CrossTableService {
 
   get cols(): Col[] {
     return this.crossTable.cols;
-  }
-
-  get rowHeaderConstraints(): Constraint[][] {
-    return this.crossTable.rowHeaderConstraints;
   }
 
   get crossTable(): CrossTable {


### PR DESCRIPTION
- Show scrollbar when cross table size exceeds panel width.
- Only enable adding cross table when none is present.
- Remove 'clear cache' button when Fractalis is not enabled.
- Do not change row constraints when loading
- Update cross table layout.

Fixes [TMT-1007](https://jira.thehyve.nl/browse/TMT-1007).