### PR TITLE
Subscribe to routing events before they are triggered

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -32,6 +32,9 @@ import {MessageHelper} from './utilities/message-helper';
 import {of as observableOf} from 'rxjs';
 import {ServerStatus} from './models/server-status';
 import {GbMainComponent} from './modules/gb-main-module/gb-main.component';
+import {Router} from '@angular/router';
+import {NavbarService} from './services/navbar.service';
+import {NavbarServiceMock} from './services/mocks/navbar.service.mock';
 
 export function initConfig(config: AppConfig) {
   return () => config.load();
@@ -42,9 +45,11 @@ describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
   let debugElement: DebugElement;
   let component: AppComponent;
+  let navbarService: NavbarService;
   let authenticationService: AuthenticationService;
   let resourceService: ResourceService;
   let config: AppConfig;
+  let router: Router;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -80,6 +85,10 @@ describe('AppComponent', () => {
           multi: true
         },
         {
+          provide: NavbarService,
+          useClass: NavbarServiceMock
+        },
+        {
           provide: AuthenticationService,
           useClass: AuthenticationServiceMock
         },
@@ -93,9 +102,11 @@ describe('AppComponent', () => {
     fixture = TestBed.createComponent(AppComponent);
     debugElement = fixture.debugElement;
     component = fixture.componentInstance;
+    navbarService = TestBed.get(NavbarService);
     authenticationService = TestBed.get(AuthenticationService);
     resourceService = TestBed.get(ResourceService);
     config = TestBed.get(AppConfig);
+    router = TestBed.get(Router);
   }));
 
   it('should be created', async(() => {
@@ -197,4 +208,15 @@ describe('AppComponent', () => {
       .toBe('There is an error connecting to the server.');
   });
 
+  it('should handle router events', () => {
+    let authenticated = true;
+    let authorisedCall = spyOnProperty(authenticationService, 'authorised', 'get')
+      .and.callFake(() => {
+        return observableOf(authenticated);
+      });
+    spyOn(router.events, 'subscribe').and.returnValue(event).and.callThrough();
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(router.events.subscribe).toHaveBeenCalled();
+  });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,6 +14,8 @@ import {ResourceService} from './services/resource.service';
 import {ServerStatus} from './models/server-status';
 import {AppConfig} from './config/app.config';
 import {AccessLevel} from './services/authentication/access-level';
+import {Router, NavigationEnd} from '@angular/router';
+import {NavbarService} from './services/navbar.service';
 
 @Component({
   selector: 'gb-app-root',
@@ -31,7 +33,9 @@ export class AppComponent implements OnInit {
 
   constructor(private authenticationService: AuthenticationService,
               private resourceService: ResourceService,
-              private config: AppConfig) {
+              private config: AppConfig,
+              private router: Router,
+              private navbarService: NavbarService) {
     if (this.config.isLoaded) {
       this.docUrl = config.getConfig('doc-url');
     }
@@ -67,6 +71,12 @@ export class AppComponent implements OnInit {
       MessageHelper.alert('error', 'Microsoft Internet Explorer is not supported\n' +
         'Some features may not work correctly.');
     }
+    this.router.events.subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        let whichStep = event.urlAfterRedirects.split('/')[1].split('#')[0];
+        this.navbarService.updateNavbar(whichStep);
+      }
+    });
   }
 
   logout() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,7 @@ import {ApiHttpInterceptor} from './services/http/api-http-interceptor.service';
 import {AuthenticationService} from './services/authentication/authentication.service';
 import {Oauth2Authentication} from './services/authentication/oauth2-authentication';
 import {GbMainModule} from './modules/gb-main-module/gb-main.module';
+import {NavbarService} from './services/navbar.service';
 
 export function initConfigAndAuth(config: AppConfig, authService: AuthenticationService) {
   return () => config.load()
@@ -45,13 +46,13 @@ export function initConfigAndAuth(config: AppConfig, authService: Authentication
     HttpClientModule,
     BrowserAnimationsModule,
     GrowlModule,
-    routing,
     GbMainModule,
     GbNavBarModule,
     GbCohortSelectionModule,
     GbAnalysisModule,
     GbSidePanelModule,
-    GbExportModule
+    GbExportModule,
+    routing
   ],
   providers: [
     DatePipe,
@@ -68,6 +69,7 @@ export function initConfigAndAuth(config: AppConfig, authService: Authentication
       useClass: ApiHttpInterceptor,
       multi: true
     },
+    NavbarService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -11,9 +11,10 @@ import {RouterModule, Routes} from '@angular/router';
 import {GbMainComponent} from './modules/gb-main-module/gb-main.component';
 
 // Route Configuration
-export const routes: Routes = [
+const routes: Routes = [
   {path: '', redirectTo: 'main/cohort-selection', pathMatch: 'full'},
   {path: 'main', component: GbMainComponent},
   {path: '**', redirectTo: '/cohort-selection'}];
 
 export const routing: ModuleWithProviders = RouterModule.forRoot(routes);
+

--- a/src/app/modules/gb-main-module/gb-main.routing.ts
+++ b/src/app/modules/gb-main-module/gb-main.routing.ts
@@ -10,7 +10,7 @@ import {ModuleWithProviders} from '@angular/core';
 import {Routes, RouterModule} from '@angular/router';
 
 // Route Configuration
-export const routes: Routes = [
+const routes: Routes = [
   {
     path: '',
     redirectTo: '/cohort-selection',

--- a/src/app/modules/gb-navbar-module/gb-navbar.component.spec.ts
+++ b/src/app/modules/gb-navbar-module/gb-navbar.component.spec.ts
@@ -23,7 +23,6 @@ import {AppConfigMock} from '../../config/app.config.mock';
 describe('GbNavbarComponent', () => {
   let component: GbNavbarComponent;
   let fixture: ComponentFixture<GbNavbarComponent>;
-  let router: Router;
   let navbarService: NavbarService;
 
   beforeEach(async(() => {
@@ -58,20 +57,12 @@ describe('GbNavbarComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GbNavbarComponent);
     component = fixture.componentInstance;
-    router = TestBed.get(Router);
     navbarService = TestBed.get(NavbarService);
-    router.initialNavigation();
     fixture.detectChanges();
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should handle router events', () => {
-    spyOn(router.events, 'subscribe').and.returnValue(event).and.callThrough();
-    component.ngOnInit();
-    expect(router.events.subscribe).toHaveBeenCalled();
   });
 
   it('should log out', () => {

--- a/src/app/modules/gb-navbar-module/gb-navbar.component.ts
+++ b/src/app/modules/gb-navbar-module/gb-navbar.component.ts
@@ -7,7 +7,6 @@
  */
 
 import {Component, OnInit} from '@angular/core';
-import {Router, NavigationEnd} from '@angular/router';
 import {NavbarService} from '../../services/navbar.service';
 import {MenuItem} from 'primeng/api';
 import {AppConfig} from '../../config/app.config';
@@ -22,20 +21,13 @@ export class GbNavbarComponent implements OnInit {
   docUrl: string;
   appVersion: string;
 
-  constructor(private router: Router,
-              private appConfig: AppConfig,
+  constructor(private appConfig: AppConfig,
               private navbarService: NavbarService) {
     this.docUrl = appConfig.getConfig('doc-url');
     this.appVersion = appConfig.version;
   }
 
   ngOnInit() {
-    this.router.events.subscribe((event) => {
-      if (event instanceof NavigationEnd) {
-        let whichStep = event.urlAfterRedirects.split('/')[1].split('#')[0];
-        this.navbarService.updateNavbar(whichStep);
-      }
-    });
   }
 
   logout() {


### PR DESCRIPTION
This prevents navbarService.updateNavbar() not being executed, when refreshing page.
Related issue: [TMT-1055](https://jira.thehyve.nl/browse/TMT-1055)