### PR TITLE
Fix root parameter encoding in '\tree' call

### DIFF
--- a/src/app/services/http/transmart-http.service.spec.ts
+++ b/src/app/services/http/transmart-http.service.spec.ts
@@ -61,10 +61,11 @@ describe('TransmartHttpService', () => {
             foo: 'bar'
           }
         };
-        service.getTreeNodes('root', 2, false, false).subscribe((res) => {
+        service.getTreeNodes('\\', 2, false, false).subscribe((res) => {
           expect(res['foo']).toBe('bar');
         });
-        const url = service.endpointUrl + '/tree_nodes?root=root&depth=2';
+        let encodedRoot = encodeURI('\\');
+        const url = service.endpointUrl + `/tree_nodes?root=${encodedRoot}&depth=2`;
         const req = httpMock.expectOne(url);
         expect(req.request.method).toEqual('GET');
         req.flush(mockData);

--- a/src/app/services/http/transmart-http.service.ts
+++ b/src/app/services/http/transmart-http.service.ts
@@ -136,7 +136,7 @@ export class TransmartHttpService {
    * @returns {Observable<Object>}
    */
   getTreeNodes(root: string, depth: number, hasCounts: boolean, hasTags: boolean): Observable<object> {
-    let urlPart = `tree_nodes?root=${root}&depth=${depth}`;
+    let urlPart = `tree_nodes?root=${encodeURIComponent(root)}&depth=${depth}`;
     if (hasCounts) {
       urlPart += '&counts=true';
     }


### PR DESCRIPTION
Tree call started failing with transmart-core [v17.2.6](https://github.com/thehyve/transmart-core/releases/tag/v17.2.6).