### PR TITLE
Allow filtering on modifier values

### DIFF
--- a/src/app/models/constraint-models/concept-constraint.ts
+++ b/src/app/models/constraint-models/concept-constraint.ts
@@ -13,6 +13,7 @@ import {TimeConstraint} from './time-constraint';
 import {TrialVisitConstraint} from './trial-visit-constraint';
 import {FormatHelper} from '../../utilities/format-helper';
 import {StudyConstraint} from './study-constraint';
+import { ModifierConstraint } from './modifier-constraint';
 
 export class ConceptConstraint extends Constraint {
 
@@ -35,6 +36,10 @@ export class ConceptConstraint extends Constraint {
   private _applyStudyConstraint = false;
   private _studyConstraint: StudyConstraint;
 
+  // modifiers
+  private _applyModifierConstraint = false;
+  private _modifierConstraints: ModifierConstraint[];
+
   constructor() {
     super();
     this.valueConstraints = [];
@@ -45,6 +50,8 @@ export class ConceptConstraint extends Constraint {
     this.trialVisitConstraint = new TrialVisitConstraint();
     this.studyConstraint = new StudyConstraint();
     this.textRepresentation = 'Concept';
+    this.applyModifierConstraint = false;
+    this.modifierConstraints = [];
   }
 
   get concept(): Concept {
@@ -133,6 +140,22 @@ export class ConceptConstraint extends Constraint {
     value.parentConstraint = this;
   }
 
+  get modifierConstraints(): ModifierConstraint[] {
+    return this._modifierConstraints;
+  }
+
+  set modifierConstraints(value: ModifierConstraint[]) {
+    this._modifierConstraints = value;
+  }
+
+  get applyModifierConstraint() {
+    return this._applyModifierConstraint;
+  }
+
+  set applyModifierConstraint(value) {
+    this._applyModifierConstraint = value;
+  }
+
   clone(): ConceptConstraint {
     const clone = new ConceptConstraint();
     clone.concept = this.concept;
@@ -146,6 +169,8 @@ export class ConceptConstraint extends Constraint {
     clone.applyStudyConstraint = this.applyStudyConstraint;
     clone.studyConstraint = this.studyConstraint.clone();
     clone.negated = this.negated;
+    clone.applyModifierConstraint = this.applyModifierConstraint;
+    clone.modifierConstraints = this.modifierConstraints.slice(0)
     return clone;
   }
 

--- a/src/app/models/constraint-models/modifier-constraint.ts
+++ b/src/app/models/constraint-models/modifier-constraint.ts
@@ -1,0 +1,31 @@
+import {Constraint} from './constraint';
+import { ValueConstraint } from './value-constraint';
+
+export class ModifierConstraint extends Constraint {
+
+  dimensionName: string;
+  path: string;
+  modifierCode: string;
+  values: ValueConstraint[];
+
+  constructor() {
+    super();
+    this.textRepresentation = 'Modifier constraint';
+    this.values = [];
+  }
+
+  get className(): string {
+    return 'ModifierConstraint';
+  }
+
+  clone(): ModifierConstraint {
+    const clone = new ModifierConstraint();
+    clone.dimensionName = this.dimensionName;
+    clone.path = this.path;
+    clone.modifierCode = this.modifierCode;
+    clone.values = this.values;
+    clone.negated = this.negated;
+    return clone;
+  }
+
+}

--- a/src/app/models/constraint-models/modifier.ts
+++ b/src/app/models/constraint-models/modifier.ts
@@ -1,0 +1,33 @@
+export class Modifier {
+    private _name: string;
+    private _path: string;
+    private _elements: string[];
+
+    constructor(name: string) {
+        this._name = name;
+        this._elements = [];
+    }
+
+    public get name(): string {
+        return this._name;
+    }
+
+    public set name(value: string) {
+        this._name = value;
+    }
+
+    public get path(): string {
+        return this._path;
+    }
+
+    public set path(value: string) {
+        this._path = value;
+    }
+
+    public get elements(): string[] {
+        return this._elements;
+    }
+    public set elements(value: string[]) {
+        this._elements = value;
+    }
+}

--- a/src/app/models/transmart-models/transmart-constraint.ts
+++ b/src/app/models/transmart-models/transmart-constraint.ts
@@ -139,3 +139,11 @@ export class TransmartRelationConstraint implements TransmartConstraint {
   biological?: boolean;
   shareHousehold?: boolean;
 }
+
+export class TransmartModifierConstraint implements TransmartConstraint {
+  type = 'modifier';
+  modifierCode?: string;
+  path?: string;
+  dimensionName?: string;
+  values: TransmartValueConstraint;
+}

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-concept-constraint/gb-concept-constraint.component.html
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-concept-constraint/gb-concept-constraint.component.html
@@ -163,6 +163,38 @@
         </div>
       </div>
 
+      <!-- modifier constraint -->
+      <div class="form-inline" [class.form-group]="applyModifierConstraint">
+        <p-checkbox [(ngModel)]="applyModifierConstraint" binary="true"></p-checkbox>
+        <label *ngIf="!applyModifierConstraint" class="gray-text">apply modifier constraint</label>
+        <div class="row">
+          <div class="col-sm">
+            <div *ngIf="applyModifierConstraint">
+              <p-listbox
+                [options]="allModifiers"
+                [(ngModel)]="selectedModifiers"
+                checkbox="true"
+                multiple="true"
+                styleClass="modifier-constraint"
+                optionLabel="name"
+                filter="true"></p-listbox>
+            </div>
+          </div>
+          <div class="col-sm">
+            <div *ngIf="applyModifierConstraint">
+              <p-listbox
+                [options]="allModifierElements"
+                [(ngModel)]="selectedModifierElements"
+                multiple="true"
+                checkbox="true"
+                filter="true"
+                styleClass="modifier-constraint-elements"
+                (onChange)="onModifierElementClick($event)"></p-listbox>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="form-inline" style="margin-bottom: -1em">
         <p-checkbox [(ngModel)]="applyStudyConstraint" binary="true"></p-checkbox>
         <label *ngIf="!applyStudyConstraint" class="gray-text">apply study constraint</label>

--- a/src/app/modules/gb-cohort-selection-module/constraint-components/gb-concept-constraint/gb-concept-constraint.component.spec.ts
+++ b/src/app/modules/gb-cohort-selection-module/constraint-components/gb-concept-constraint/gb-concept-constraint.component.spec.ts
@@ -10,7 +10,7 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {GbConceptConstraintComponent} from './gb-concept-constraint.component';
 import {FormsModule} from '@angular/forms';
-import {AutoCompleteModule, CalendarModule, CheckboxModule, MultiSelectModule, PanelModule} from 'primeng/primeng';
+import {AutoCompleteModule, CalendarModule, CheckboxModule, MultiSelectModule, PanelModule, ListboxModule} from 'primeng/primeng';
 import {TreeNodeService} from '../../../../services/tree-node.service';
 import {TreeNodeServiceMock} from '../../../../services/mocks/tree-node.service.mock';
 import {ResourceService} from '../../../../services/resource.service';
@@ -61,7 +61,8 @@ describe('GbConceptConstraintComponent', () => {
         CheckboxModule,
         CalendarModule,
         PanelModule,
-        MultiSelectModule
+        MultiSelectModule,
+        ListboxModule,
       ],
       providers: [
         {

--- a/src/app/modules/gb-cohort-selection-module/gb-cohort-selection.module.ts
+++ b/src/app/modules/gb-cohort-selection-module/gb-cohort-selection.module.ts
@@ -25,7 +25,8 @@ import {
   DataListModule,
   TreeTableModule,
   DropdownModule,
-  MessagesModule, PaginatorModule, MultiSelectModule, OverlayPanelModule, InputSwitchModule
+  MessagesModule, PaginatorModule, MultiSelectModule, OverlayPanelModule, InputSwitchModule,
+  ListboxModule
 } from 'primeng/primeng';
 import {GbSubjectSetConstraintComponent} from './constraint-components/gb-subject-set-constraint/gb-subject-set-constraint.component';
 import {GbPedigreeConstraintComponent} from './constraint-components/gb-pedigree-constraint/gb-pedigree-constraint.component';
@@ -49,6 +50,7 @@ import {GbPedigreeConstraintComponent} from './constraint-components/gb-pedigree
     OverlayPanelModule,
     InputSwitchModule,
     DropdownModule,
+    ListboxModule,
   ],
   exports: [
     RouterModule

--- a/src/app/services/http/transmart-http.service.ts
+++ b/src/app/services/http/transmart-http.service.ts
@@ -21,13 +21,15 @@ import {TransmartConstraintMapper} from '../../utilities/transmart-utilities/tra
 import {ErrorHelper} from '../../utilities/error-helper';
 import {TransmartCountItem} from '../../models/transmart-models/transmart-count-item';
 import {TransmartStudy} from '../../models/transmart-models/transmart-study';
-import {catchError, map} from 'rxjs/operators';
+import {catchError, map, flatMap} from 'rxjs/operators';
 import {TransmartTrialVisit} from '../../models/transmart-models/transmart-trial-visit';
 import {HttpHelper} from '../../utilities/http-helper';
 import {HttpClient, HttpErrorResponse} from '@angular/common/http';
 import {TransmartExportJob} from '../../models/transmart-models/transmart-export-job';
 import {TransmartPatient} from '../../models/transmart-models/transmart-patient';
 import {TransmartDimension} from '../../models/transmart-models/transmart-dimension';
+import { Concept } from 'app/models/constraint-models/concept';
+import { Modifier } from 'app/models/constraint-models/modifier';
 
 
 @Injectable({
@@ -236,6 +238,18 @@ export class TransmartHttpService {
     return this.httpHelper.postCall(urlPart, body, responseField);
   }
 
+  // -------------------------------------- modifier calls --------------------------------------
+  /**
+   * Given a concept, find all modifiers that exist ofr it
+   * @param concept
+   * @returns {Observable<R|T>}
+   */
+  getModifiers(concept: Concept): Observable<string[]> {
+    const urlPart = `concepts/${concept.code}/modifiers`;
+    const responseField = 'modifiers';
+    return this.httpHelper.getCall(urlPart, responseField);
+  }
+
   // -------------------------------------- pedigree calls --------------------------------------
   /**
    * Get the available pedigree relation types such as parent, child, spouse, sibling and various twin types
@@ -441,6 +455,12 @@ export class TransmartHttpService {
     const urlPart = 'dimensions';
     const responseField = 'dimensions';
     return this.httpHelper.getCall(urlPart, responseField);
+  }
+
+  getModifierElements(modifierName: string): Observable<string[]> {
+    const urlPart = `dimensions/${modifierName}/elements`;
+    const responseField = 'elements';
+    return this.httpHelper.postCall(urlPart, null, responseField);
   }
 
 }

--- a/src/app/services/resource.service.ts
+++ b/src/app/services/resource.service.ts
@@ -39,6 +39,7 @@ import {CohortMapper} from '../utilities/cohort-utilities/cohort-mapper';
 import {Dimension} from '../models/constraint-models/dimension';
 import {TransmartDimension} from '../models/transmart-models/transmart-dimension';
 import {ServerStatus} from '../models/server-status';
+import { Concept } from 'app/models/constraint-models/concept';
 
 @Injectable({
   providedIn: 'root',
@@ -174,6 +175,25 @@ export class ResourceService {
       map((tmTrialVisits: TransmartTrialVisit[]) => {
         return TransmartMapper.mapTransmartTrialVisits(tmTrialVisits);
       }));
+  }
+
+  // -------------------------------------- modifier calls --------------------------------------
+  /**
+   * Given a concept, find the modifiers that exist for it
+   * @param concept
+   * @returns {Observable<R|T>}
+   */
+  getModifiers(concept: Concept): Observable<string[]> {
+    return this.transmartResourceService.getModifiers(concept);
+  }
+
+  /**
+   * Find all elements for a given modifier
+   * @param concept
+   * @returns {Observable<R|T>}
+   */
+  getModifierElements(modifierName: string): Observable<string[]> {
+    return this.transmartResourceService.getModifierElements(modifierName);
   }
 
   // -------------------------------------- pedigree calls --------------------------------------

--- a/src/app/services/transmart-resource.service.ts
+++ b/src/app/services/transmart-resource.service.ts
@@ -37,6 +37,7 @@ import {TransmartExportJob} from '../models/transmart-models/transmart-export-jo
 import {TransmartPatient} from '../models/transmart-models/transmart-patient';
 import {TransmartDimension} from '../models/transmart-models/transmart-dimension';
 import {ServerStatus} from '../models/server-status';
+import { Concept } from 'app/models/constraint-models/concept';
 
 
 @Injectable({
@@ -310,6 +311,25 @@ export class TransmartResourceService {
    */
   getTrialVisits(constraint: Constraint): Observable<TransmartTrialVisit[]> {
     return this.transmartHttpService.getTrialVisits(constraint);
+  }
+
+  // -------------------------------------- modifier calls --------------------------------------
+  /**
+   * Given a concept, find the modifiers that exist for it
+   * @param concept
+   * @returns {Observable<R|T>}
+   */
+  getModifiers(concept: Concept): Observable<string[]> {
+    return this.transmartHttpService.getModifiers(concept);
+  }
+
+  /**
+   * Get all elements for a modifier
+   * @param modifierName
+   * @returns {Observable<R|T>}
+   */
+  getModifierElements(modifierName: string): Observable<string[]> {
+    return this.transmartHttpService.getModifierElements(modifierName);
   }
 
   // -------------------------------------- pedigree calls --------------------------------------

--- a/src/app/utilities/constraint-utilities/abstract-constraint-visitor.ts
+++ b/src/app/utilities/constraint-utilities/abstract-constraint-visitor.ts
@@ -18,6 +18,7 @@ import {SubjectSetConstraint} from '../../models/constraint-models/subject-set-c
 import {CombinationConstraint} from '../../models/constraint-models/combination-constraint';
 import {TrialVisitConstraint} from '../../models/constraint-models/trial-visit-constraint';
 import {StudyConstraint} from '../../models/constraint-models/study-constraint';
+import { ModifierConstraint } from 'app/models/constraint-models/modifier-constraint';
 
 export abstract class AbstractConstraintVisitor<T> implements ConstraintVisitor<T> {
 
@@ -54,6 +55,8 @@ export abstract class AbstractConstraintVisitor<T> implements ConstraintVisitor<
         return this.visitTrialVisitConstraint(<TrialVisitConstraint>constraint);
       case 'TimeConstraint':
         return this.visitTimeConstraint(<TimeConstraint>constraint);
+      case 'ModifierConstraint':
+        return this.visitModifierConstraint(<ModifierConstraint>constraint);
       default:
         throw new Error(`Unsupported constraint type: ${constraint.className}`);
     }
@@ -78,5 +81,7 @@ export abstract class AbstractConstraintVisitor<T> implements ConstraintVisitor<
   abstract visitTrialVisitConstraint(constraint: TrialVisitConstraint): T;
 
   abstract visitTimeConstraint(constraint: TimeConstraint): T;
+
+  abstract visitModifierConstraint(constraint: ModifierConstraint): T;
 
 }

--- a/src/app/utilities/constraint-utilities/constraint-serialiser.ts
+++ b/src/app/utilities/constraint-utilities/constraint-serialiser.ts
@@ -11,6 +11,7 @@ import {ConceptConstraint} from '../../models/constraint-models/concept-constrai
 import {CombinationConstraint} from '../../models/constraint-models/combination-constraint';
 import {Concept} from '../../models/constraint-models/concept';
 import {Constraint} from '../../models/constraint-models/constraint';
+import { ModifierConstraint } from 'app/models/constraint-models/modifier-constraint';
 
 /**
  * A simple constraint serialisation class for debugging purposes.
@@ -72,6 +73,9 @@ export class ConstraintSerialiser extends AbstractConstraintVisitor<object> {
     }
     if (constraint.applyStudyConstraint) {
       result['studyConstraint'] = this.visit(constraint.studyConstraint);
+    }
+    if (constraint.applyModifierConstraint) {
+      result['modifierConstraint'] = constraint.modifierConstraints.map(constraint => this.visit(constraint));
     }
     return result;
   }
@@ -139,8 +143,15 @@ export class ConstraintSerialiser extends AbstractConstraintVisitor<object> {
     return {
       studies: constraint.operator,
       valueType: constraint.valueType,
-      value: constraint.value
+      value: constraint.value,
     };
+  }
+
+  visitModifierConstraint(constraint: ModifierConstraint): object {
+    return {
+      dimensionName: constraint.dimensionName,
+      values: constraint.values,
+    }
   }
 
   visit(constraint: Constraint): object {

--- a/src/app/utilities/transmart-utilities/abstract-transmart-constraint-visitor.ts
+++ b/src/app/utilities/transmart-utilities/abstract-transmart-constraint-visitor.ts
@@ -21,7 +21,8 @@ import {
   TransmartTemporalConstraint,
   TransmartTimeConstraint,
   TransmartTrueConstraint,
-  TransmartValueConstraint
+  TransmartValueConstraint,
+  TransmartModifierConstraint
 } from '../../models/transmart-models/transmart-constraint';
 
 export abstract class AbstractTransmartConstraintVisitor<T> implements TransmartConstraintVisitor<T> {
@@ -59,6 +60,8 @@ export abstract class AbstractTransmartConstraintVisitor<T> implements Transmart
         return this.visitSubSelectionConstraint(<TransmartSubSelectionConstraint>constraint);
       case 'relation':
         return this.visitRelationConstraint(<TransmartRelationConstraint>constraint);
+      case 'modifier':
+        return this.visitModifierConstraint(<TransmartModifierConstraint>constraint);
       default:
         throw new Error(`Unsupported constraint type: ${constraint.type}`);
     }
@@ -97,5 +100,7 @@ export abstract class AbstractTransmartConstraintVisitor<T> implements Transmart
   abstract visitSubSelectionConstraint(constraint: TransmartSubSelectionConstraint): T;
 
   abstract visitRelationConstraint(constraint: TransmartRelationConstraint): T;
+
+  abstract visitModifierConstraint(constraint: TransmartModifierConstraint): T;
 
 }

--- a/src/app/utilities/transmart-utilities/transmart-constraint-reader.ts
+++ b/src/app/utilities/transmart-utilities/transmart-constraint-reader.ts
@@ -15,7 +15,8 @@ import {
   TransmartTemporalConstraint,
   TransmartTimeConstraint,
   TransmartTrueConstraint,
-  TransmartValueConstraint
+  TransmartValueConstraint,
+  TransmartModifierConstraint
 } from '../../models/transmart-models/transmart-constraint';
 import {Concept} from '../../models/constraint-models/concept';
 import {ConceptConstraint} from '../../models/constraint-models/concept-constraint';
@@ -337,6 +338,10 @@ export class TransmartConstraintReader extends AbstractTransmartConstraintVisito
 
   visitTrueConstraint(constraintObject: TransmartTrueConstraint): Constraint {
     return new TrueConstraint();
+  }
+
+  visitModifierConstraint(constraintObject: TransmartModifierConstraint): Constraint {
+    throw new Error(`Constraint type not supported: ${constraintObject.type}`)
   }
 
 }

--- a/src/app/utilities/transmart-utilities/transmart-constraint-rewriter.ts
+++ b/src/app/utilities/transmart-utilities/transmart-constraint-rewriter.ts
@@ -10,7 +10,8 @@ import {
   TransmartTemporalConstraint,
   TransmartTimeConstraint,
   TransmartTrueConstraint,
-  TransmartValueConstraint
+  TransmartValueConstraint,
+  TransmartModifierConstraint
 } from '../../models/transmart-models/transmart-constraint';
 
 /**
@@ -127,6 +128,10 @@ export class TransmartConstraintRewriter extends AbstractTransmartConstraintVisi
   }
 
   visitValueConstraint(constraint: TransmartValueConstraint): TransmartConstraint {
+    return Object.assign({}, constraint);
+  }
+
+  visitModifierConstraint(constraint: TransmartModifierConstraint): TransmartConstraint {
     return Object.assign({}, constraint);
   }
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -168,3 +168,19 @@ body .hline {
 .form-control:-ms-input-placeholder {
   color: lightgray;
 }
+
+.modifier-constraint {
+  height: 150px !important;
+  overflow-y: scroll !important;
+}
+
+.modifier-constraint-elements {
+  height: 150px !important;
+  overflow-y: scroll !important;
+}
+
+.modifier-constraint:not(.ui-state-disabled) .ui-listbox-item:hover,
+.modifier-constraint-elements:not(.ui-state-disabled) .ui-listbox-item:hover {
+  background-color: var(--gb-clinical-green) !important;
+  color: #ffffff !important;
+}


### PR DESCRIPTION
This in conjunction with https://github.com/thehyve/transmart-core/pull/481 adds a feature to filter on modifier values for a particular concept. The different modifier values would be ORed together in the constraint.

For an example, consider `Demo Concept`, which might be modified by `Compound Names`. The feature allows filtering on a subset of `Compound Names` as demonstrated in the example below:

**Option to apply `modifier constraint`**
![Option to apply `modifier constraint`](https://i.imgur.com/FCDLN7w.png)

**Option to select and filter constraints and their values**
![Option to select and filter constraints and their values](https://i.imgur.com/qZPiGlD.png)
