### PR TITLE
Release version 2.0.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ deploy:
     on:
       all_branches: true
       node_js: '12'
-      condition: $TRAVIS_BRANCH =~ ^(dev|master)$
+      condition: $TRAVIS_BRANCH =~ ^(dev|release)$
 
 # For deployment to Docker Hub, configure the `DOCKER_USERNAME` and `DOCKER_PASSWORD` variables:
 # - `travis env set DOCKER_USERNAME ...`

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ gradle assemble
 gradle publish
 ```
 
-The latest release is [glowing-bear-2.0.11.tar](https://repo.thehyve.nl/service/local/repositories/releases/content/nl/thehyve/glowing-bear/2.0.11/glowing-bear-2.0.11.tar).
+The latest release is [glowing-bear-2.0.12.tar](https://repo.thehyve.nl/service/local/repositories/releases/content/nl/thehyve/glowing-bear/2.0.12/glowing-bear-2.0.12.tar).
 
 Published snapshot bundles are available in the `snapshots` repository
 on https://repo.thehyve.nl with id `nl.thehyve:glowing-bear:0.0.1-SNAPSNOT:tar`.
@@ -178,7 +178,7 @@ All extensions require a proper configuration, as described in [configuration](#
 
 ## License
 
-Copyright &copy; 2017&ndash;2019 &nbsp; The Hyve B.V.
+Copyright &copy; 2017&ndash;2021 &nbsp; The Hyve B.V.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the [Mozilla Public License 2.0](LICENSE).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,12 +4,6 @@ ARG GB_VERSION="2.0.11"
 ARG GB_SRC_REPOSITORY="releases"
 
 ENV GB_SRC_URL https://repo.thehyve.nl/service/local/artifact/maven/redirect?r=${GB_SRC_REPOSITORY}&g=nl.thehyve&a=glowing-bear&v=${GB_VERSION}&p=tar
-ENV NGINX_HOST="${NGINX_HOST:-localhost}"
-ENV NGINX_PORT="${NGINX_PORT:-80}"
-
-ENV AUTOSAVE_SUBJECT_SETS=${AUTOSAVE_SUBJECT_SETS:-false}
-ENV CHECK_SERVER_STATUS=${CHECK_SERVER_STATUS:-false}
-ENV DENY_ACCESS_WITHOUT_ROLE=${DENY_ACCESS_WITHOUT_ROLE:-false}
 
 WORKDIR /usr/share/nginx/html
 
@@ -21,8 +15,21 @@ RUN apk add curl && \
     curl -f -L "${GB_SRC_URL}" -o "glowing-bear-${GB_VERSION}.tar" && \
     tar -xf "glowing-bear-${GB_VERSION}.tar" --strip 1
 
-# apply env variables to the application config and nginx config, while starting the webserver
-CMD ["/bin/sh", "-c", "\
-      envsubst '$${NGINX_HOST}, $${NGINX_PORT}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && \
-      envsubst < /usr/share/nginx/html/config.template.json > /usr/share/nginx/html/app/config/config.default.json && \
-      exec nginx -g 'daemon off;'"]
+COPY docker-entrypoint.sh /opt/docker-entrypoint.sh
+
+ENV NGINX_HOST="${NGINX_HOST:-localhost}"
+ENV NGINX_PORT="${NGINX_PORT:-80}"
+
+ENV TRANSMART_API_SERVER_URL=${TRANSMART_API_SERVER_URL:-http://transmart-api-server:8081}
+ENV GB_BACKEND_URL=${GB_BACKEND_URL:-http://gb-backend:8083}
+ENV TRANSMART_PACKER_URL=${TRANSMART_PACKER_URL:-http://transmart-packer:8999}
+
+ENV KEYCLOAK_SERVER_URL=${KEYCLOAK_SERVER_URL}
+ENV KEYCLOAK_REALM=${KEYCLOAK_REALM}
+ENV KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID}
+
+ENV AUTOSAVE_SUBJECT_SETS=${AUTOSAVE_SUBJECT_SETS:-false}
+ENV CHECK_SERVER_STATUS=${CHECK_SERVER_STATUS:-false}
+ENV DENY_ACCESS_WITHOUT_ROLE=${DENY_ACCESS_WITHOUT_ROLE:-false}
+
+ENTRYPOINT ["/opt/docker-entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:alpine
 
-ARG GB_VERSION="2.0.11"
+ARG GB_VERSION="2.0.12"
 ARG GB_SRC_REPOSITORY="releases"
 
 ENV GB_SRC_URL https://repo.thehyve.nl/service/local/artifact/maven/redirect?r=${GB_SRC_REPOSITORY}&g=nl.thehyve&a=glowing-bear&v=${GB_VERSION}&p=tar

--- a/docker/config.template.json
+++ b/docker/config.template.json
@@ -1,7 +1,7 @@
 {
-  "api-url": "${TRANSMART_API_SERVER_URL}",
+  "api-url": "/api/transmart-api-server",
   "api-version": "v2",
-  "gb-backend-url": "${GB_BACKEND_URL}",
+  "gb-backend-url": "/api/gb-backend",
   "doc-url": "https://glowingbear.app",
   "enable-fractalis-analysis": false,
   "autosave-subject-sets": ${AUTOSAVE_SUBJECT_SETS},
@@ -14,7 +14,7 @@
   "export-mode": {
     "name": "packer",
     "data-view": "basic_export",
-    "export-url": "${TRANSMART_PACKER_URL}"
+    "export-url": "/api/transmart-packer"
   },
   "check-server-status": ${CHECK_SERVER_STATUS},
   "deny-access-to-users-without-role": ${DENY_ACCESS_WITHOUT_ROLE}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+# Error message and exit for missing environment variable
+fatal() {
+		cat << EndOfMessage
+--------------------------------------------------------------
+Fatal error!
+--------------------------------------------------------------
+The variable with the name '$1' is unset.
+Please specify a value in this container environment using
+-e in docker run or the environment section in docker-compose.
+--------------------------------------------------------------
+EndOfMessage
+		exit 1
+}
+
+# Check that Keycloak is configured via environment variables
+[ -n "${KEYCLOAK_SERVER_URL}" ] || fatal 'KEYCLOAK_SERVER_URL'
+[ -n "${KEYCLOAK_REALM}" ] || fatal 'KEYCLOAK_REALM'
+[ -n "${KEYCLOAK_CLIENT_ID}" ] || fatal 'KEYCLOAK_CLIENT_ID'
+
+envsubst '$${NGINX_HOST}, $${NGINX_PORT}, $${TRANSMART_API_SERVER_URL}, $${GB_BACKEND_URL}, $${TRANSMART_PACKER_URL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && \
+echo '{"env": "default"}' > /usr/share/nginx/html/app/config/env.json && \
+cat /usr/share/nginx/html/app/config/env.json && \
+envsubst < /usr/share/nginx/html/config.template.json > /usr/share/nginx/html/app/config/config.default.json && \
+exec nginx -g 'daemon off;'

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -17,7 +17,7 @@ http {
     }
 
     location /api/transmart-api-server/ {
-      proxy_pass            http://transmart-api-server:8081/;
+      proxy_pass            ${TRANSMART_API_SERVER_URL}/;
       proxy_read_timeout    90s;
       proxy_connect_timeout 90s;
       proxy_send_timeout    90s;
@@ -28,7 +28,7 @@ http {
     }
 
     location /api/gb-backend/ {
-      proxy_pass            http://gb-backend:8083/;
+      proxy_pass            ${GB_BACKEND_URL}/;
       proxy_read_timeout    90s;
       proxy_connect_timeout 90s;
       proxy_send_timeout    90s;
@@ -39,7 +39,7 @@ http {
     }
 
     location /api/transmart-packer/ {
-      proxy_pass            http://transmart-packer:8999/;
+      proxy_pass            ${TRANSMART_PACKER_URL}/;
       proxy_read_timeout    90s;
       proxy_connect_timeout 90s;
       proxy_send_timeout    90s;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glowing-bear",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "license": "GPL-3.0+",
   "scripts": {
     "ng": "ng",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,10 +2219,10 @@ bluebird@3.7.2, bluebird@^3.3.0, bluebird@^3.4.1, bluebird@^3.5.1, bluebird@^3.5
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
-  version "4.11.9"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
-  integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
 bn.js@^5.1.1:
   version "5.1.2"
@@ -2293,7 +2293,7 @@ braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brorand@^1.0.1:
+brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -4504,17 +4504,17 @@ elegant-spinner@^1.0.1:
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
 elliptic@^6.0.0, elliptic@^6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
-  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
   dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
     hash.js "^1.0.0"
-    hmac-drbg "^1.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -5552,7 +5552,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-hmac-drbg@^1.0.0:
+hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
@@ -7169,7 +7169,7 @@ minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
+minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=


### PR DESCRIPTION
This update is needed to fix the proxy routes for glowing-bear-docker, e.g., on https://glowingbear-demo.thehyve.net.